### PR TITLE
[BM-173] Fix failing "build-staging" bitrise task

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -217,7 +217,7 @@ workflows:
 
   archive-xcode:
     steps:
-      - xcode-archive:
+      - xcode-archive@2.4.15:
           inputs:
             - project_path: $XCODEBUILD_PROJECT
             - scheme: $XCODEBUILD_SCHEME


### PR DESCRIPTION
### Ticket
https://netguru.atlassian.net/browse/BM-173
 
 
### Task Description
Fix failing "build-staging" bitrise task
 
 
### Aditional Notes (optional)
Downgraded xcode-archive step from the most recent (2.4.16) to 2.4.15.
See also:
https://github.com/bitrise-io/steps-xcode-archive/issues/129