### PR TITLE
[BM-347] Change initialisation logic of webrtc service

### DIFF
--- a/Baby Monitor/Source Files/AppDependencies.swift
+++ b/Baby Monitor/Source Files/AppDependencies.swift
@@ -51,9 +51,9 @@ final class AppDependencies {
         return WebSocketConductor(webSocket: self.webSocket, messageEmitter: emitter, messageHandler: handler, messageDecoders: self.webRtcMessageDecoders)
     }
     private(set) lazy var webSocketEventMessageService: WebSocketEventMessageServiceProtocol = WebSocketEventMessageService(cryingEventsRepository: databaseRepository, eventMessageConductorFactory: eventMessageConductorFactory)
-    private(set) lazy var webSocketWebRtcService: (WebRtcClientManagerProtocol) -> WebSocketWebRtcServiceProtocol = { webRtcClient in
-        return WebSocketWebRtcService(webRtcClientManager: webRtcClient, webRtcConductorFactory: self.webRtcConductorFactory)
-    }
+    private(set) lazy var webSocketWebRtcService: WebSocketWebRtcServiceProtocol = {
+        return WebSocketWebRtcService(webRtcClientManager: webRtcClient(), webRtcConductorFactory: self.webRtcConductorFactory)
+    }()
     private(set) lazy var networkDispatcher: NetworkDispatcherProtocol = NetworkDispatcher(
         urlSession: URLSession(configuration: .default),
         dispatchQueue: DispatchQueue(label: "NetworkDispatcherQueue")

--- a/Baby Monitor/Source Files/Modules/Dashboard/DashboardCoordinator.swift
+++ b/Baby Monitor/Source Files/Modules/Dashboard/DashboardCoordinator.swift
@@ -110,7 +110,7 @@ final class DashboardCoordinator: Coordinator {
 
     // Prepare CameraPreviewViewModel
     private func createCameraPreviewViewModel() -> CameraPreviewViewModel {
-        let viewModel = CameraPreviewViewModel(webSocketWebRtcService: appDependencies.webSocketWebRtcService(appDependencies.webRtcClient()), babyModelController: appDependencies.databaseRepository)
+        let viewModel = CameraPreviewViewModel(webSocketWebRtcService: appDependencies.webSocketWebRtcService, babyModelController: appDependencies.databaseRepository)
         return viewModel
     }
     


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-347
 
 
### Task Description
Image transmission takes too long to show the camera view. After connecting to the devices, and tapping on Camera View, it takes too long for camera view to show up (to see what baby app is seeing)