### PR TITLE
[BM-521] Parent device - App crash on connecting to baby stream

### DIFF
--- a/Baby Monitor/Source Files/Services/Websocket/WebSocketProtocol.swift
+++ b/Baby Monitor/Source Files/Services/Websocket/WebSocketProtocol.swift
@@ -65,9 +65,10 @@ final class PSWebSocketWrapper: NSObject, WebSocketProtocol {
     }
     
     func open() {
-        guard !isConnected else {
+        guard !isConnected && (socket.readyState == .connecting) else {
             return
         }
+        isConnected = true
         socket.open()
     }
     

--- a/Baby Monitor/Source Files/Services/Websocket/WebSocketProtocol.swift
+++ b/Baby Monitor/Source Files/Services/Websocket/WebSocketProtocol.swift
@@ -68,6 +68,8 @@ final class PSWebSocketWrapper: NSObject, WebSocketProtocol {
         guard !isConnected && (socket.readyState == .connecting) else {
             return
         }
+        // This is a workaround for a library bug.
+        // TODO: add more description of a workaround. 
         isConnected = true
         socket.open()
     }


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-521

### Task Description

AS WAS
👶- iPhone 8 iOS v. 12.0
👨 - iPhone XS MAX iOS v. 12.0.1

I set up the baby device stream and started to set up the parent device, after connecting to the baby device (screen with Your baby name, devices connected status) I hit the baby face icon to open the stream, and  the app crashed on parent device

AS IS
Hopefully, the app won't crash more. The cause was in web socket library not calling a delegate when the connecting was open as I see it. The library is no longer maintained so I introduced a quick fix for that.

