### PR TITLE
[BM-534]  Set limit 1 notification per 1 minute

### DIFF
--- a/Baby Monitor/Resources/Constants.swift
+++ b/Baby Monitor/Resources/Constants.swift
@@ -13,6 +13,9 @@ enum Constants {
     static let domain = "local."
     static let netServiceName = "Baby Monitor Service"
     static let cryingDetectionThreshold = 0.7
+
+    /// A limit per which one notification can be sent.
+    static let notificationRequestTimeLimit: TimeInterval = 60
     
     /// Represents a size class for constraint constants
     enum ResponsiveSizeClass {

--- a/Baby Monitor/Source Files/Services/ServerService.swift
+++ b/Baby Monitor/Source Files/Services/ServerService.swift
@@ -58,9 +58,9 @@ final class ServerService: ServerServiceProtocol {
     private func rxSetup() {
         cryingEventService.cryingEventObservable
             .throttle(Constants.notificationRequestTimeLimit, scheduler: MainScheduler.instance)
-            .subscribe(onNext: { [unowned self] _ in
-            self.notificationsService.sendPushNotificationsRequest()
-        }).disposed(by: disposeBag)
+            .subscribe(onNext: { [weak self] _ in
+                self?.notificationsService.sendPushNotificationsRequest()
+            }).disposed(by: disposeBag)
         messageServer.decodedMessage(using: decoders)
             .subscribe(onNext: { [unowned self] message in
                 guard let message = message else {

--- a/Baby Monitor/Source Files/Services/ServerService.swift
+++ b/Baby Monitor/Source Files/Services/ServerService.swift
@@ -56,7 +56,9 @@ final class ServerService: ServerServiceProtocol {
     }
     
     private func rxSetup() {
-        cryingEventService.cryingEventObservable.subscribe(onNext: { [unowned self] _ in
+        cryingEventService.cryingEventObservable
+            .throttle(Constants.notificationRequestTimeLimit, scheduler: MainScheduler.instance)
+            .subscribe(onNext: { [unowned self] _ in
             self.notificationsService.sendPushNotificationsRequest()
         }).disposed(by: disposeBag)
         messageServer.decodedMessage(using: decoders)


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-534
 
 
### Task Description
<!-- What should and what actually happens. -->
  Set limit so that maximum 1 notification will be sent per 1 minute, so it would be consistent with Android.
 