### PR TITLE
[BM-502] Baby device - iOS doesn't disable video preview

### DIFF
--- a/Baby Monitor.xcodeproj/project.pbxproj
+++ b/Baby Monitor.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		95368F522209BC36006E263A /* SpecifyDeviceInfoOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95368F512209BC36006E263A /* SpecifyDeviceInfoOnboardingViewController.swift */; };
 		95368F552209BC6A006E263A /* SpecifyDeviceInfoOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95368F542209BC6A006E263A /* SpecifyDeviceInfoOnboardingView.swift */; };
 		95368F582209BCC6006E263A /* SpecifyDeviceInfoOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95368F572209BCC6006E263A /* SpecifyDeviceInfoOnboardingViewModel.swift */; };
+		9566206E2359ADF900ACBC94 /* DisabledVideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9566206D2359ADF900ACBC94 /* DisabledVideoView.swift */; };
 		959162E52200BAD2008F28B4 /* UIDevice+ScreenSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959162E42200BAD2008F28B4 /* UIDevice+ScreenSize.swift */; };
 		A1492A66221D814500AA7716 /* ClearableLazyItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1492A65221D814500AA7716 /* ClearableLazyItem.swift */; };
 		A1572D8B22005AF600AC57C4 /* ActivityLogCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1572D8A22005AF600AC57C4 /* ActivityLogCell.swift */; };
@@ -536,6 +537,7 @@
 		95368F512209BC36006E263A /* SpecifyDeviceInfoOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyDeviceInfoOnboardingViewController.swift; sourceTree = "<group>"; };
 		95368F542209BC6A006E263A /* SpecifyDeviceInfoOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyDeviceInfoOnboardingView.swift; sourceTree = "<group>"; };
 		95368F572209BCC6006E263A /* SpecifyDeviceInfoOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyDeviceInfoOnboardingViewModel.swift; sourceTree = "<group>"; };
+		9566206D2359ADF900ACBC94 /* DisabledVideoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisabledVideoView.swift; sourceTree = "<group>"; };
 		959162E42200BAD2008F28B4 /* UIDevice+ScreenSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+ScreenSize.swift"; sourceTree = "<group>"; };
 		A1492A65221D814500AA7716 /* ClearableLazyItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearableLazyItem.swift; sourceTree = "<group>"; };
 		A1572D8A22005AF600AC57C4 /* ActivityLogCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityLogCell.swift; sourceTree = "<group>"; };
@@ -984,6 +986,7 @@
 				200DFD4621F87862009CA3ED /* RoundedRectangleButton.swift */,
 				A1640E2A22048EA100398ED2 /* BabyMonitorSwitch.swift */,
 				3A3C61AB223EC2140020FD3D /* StreamVideoView.swift */,
+				9566206D2359ADF900ACBC94 /* DisabledVideoView.swift */,
 			);
 			path = "Custom Views";
 			sourceTree = "<group>";
@@ -1846,6 +1849,7 @@
 				8A7A611B21A59E5000488ED4 /* MemoryCleaner.swift in Sources */,
 				8A7A611C21A59E5000488ED4 /* ActivityLogEvent.swift in Sources */,
 				4E1D2C6521678D9100E92F29 /* TypedViewController.swift in Sources */,
+				9566206E2359ADF900ACBC94 /* DisabledVideoView.swift in Sources */,
 				4EA2802621E8C6B200262E45 /* DateFormatter+Helpers.swift in Sources */,
 				A1640E2B22048EA100398ED2 /* BabyMonitorSwitch.swift in Sources */,
 				A7D7562522344B0300F9893E /* NodeCapture.swift in Sources */,

--- a/Baby Monitor/Resources/Constants.swift
+++ b/Baby Monitor/Resources/Constants.swift
@@ -18,7 +18,7 @@ enum Constants {
     static let notificationRequestTimeLimit: TimeInterval = 60
 
     /// A time after which the video stream should be hidden.
-    static let videoStreamingHiddenAfterTime: TimeInterval = 5  * 60
+    static let videoStreamingHiddenAfterTime: TimeInterval = 60
     
     /// Represents a size class for constraint constants
     enum ResponsiveSizeClass {

--- a/Baby Monitor/Resources/Constants.swift
+++ b/Baby Monitor/Resources/Constants.swift
@@ -16,6 +16,9 @@ enum Constants {
 
     /// A limit per which one notification can be sent.
     static let notificationRequestTimeLimit: TimeInterval = 60
+
+    /// A time after which the video stream should be hidden.
+    static let videoStreamingHiddenAfterTime: TimeInterval = 5  * 60
     
     /// Represents a size class for constraint constants
     enum ResponsiveSizeClass {

--- a/Baby Monitor/Resources/Constants.swift
+++ b/Baby Monitor/Resources/Constants.swift
@@ -18,7 +18,7 @@ enum Constants {
     static let notificationRequestTimeLimit: TimeInterval = 60
 
     /// A time after which the video stream should be hidden.
-    static let videoStreamingHiddenAfterTime: TimeInterval = 60
+    static let videoStreamVisibilityTimeLimit: TimeInterval = 60
     
     /// Represents a size class for constraint constants
     enum ResponsiveSizeClass {

--- a/Baby Monitor/Source Files/Custom Views/DisabledVideoView.swift
+++ b/Baby Monitor/Source Files/Custom Views/DisabledVideoView.swift
@@ -1,0 +1,53 @@
+//
+//  DisabledVideoView.swift
+//  Baby Monitor
+//
+
+import UIKit
+
+final class DisabledVideoView: BaseView {
+
+    private let babyLogoView: UIImageView = {
+        let view = UIImageView(image: #imageLiteral(resourceName: "childPurple"))
+        view.contentMode = .scaleAspectFit
+        return view
+    }()
+
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.customFont(withSize: .body, weight: .light)
+        label.textColor = .babyMonitorNonTranslucentWhite
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.text = Localizable.Video.videoDisabledDescription
+        return label
+    }()
+
+    override init() {
+        super.init()
+        setup()
+    }
+
+    private func setup() {
+        [babyLogoView, descriptionLabel].forEach {
+            addSubview($0)
+        }
+        setupConstraints()
+    }
+
+    private func setupConstraints() {
+        babyLogoView.addConstraints {[
+            $0.equal(.centerY, constant: -150),
+            $0.equal(.centerX),
+            $0.equalConstant(.height, 120)
+        ]
+        }
+
+        descriptionLabel.addConstraints {[
+            $0.equal(.centerX),
+            $0.equalTo(babyLogoView, .top, .bottom, constant: 25),
+            $0.equal(.width, multiplier: 0.8)
+        ]
+        }
+    }
+}

--- a/Baby Monitor/Source Files/Custom Views/DisabledVideoView.swift
+++ b/Baby Monitor/Source Files/Custom Views/DisabledVideoView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 final class DisabledVideoView: BaseView {
 
-    private(set) var tapGestureRecognizer = UITapGestureRecognizer()
+    let tapGestureRecognizer = UITapGestureRecognizer()
 
     private let babyLogoView: UIImageView = {
         let view = UIImageView(image: #imageLiteral(resourceName: "childPurple"))

--- a/Baby Monitor/Source Files/Custom Views/DisabledVideoView.swift
+++ b/Baby Monitor/Source Files/Custom Views/DisabledVideoView.swift
@@ -7,6 +7,7 @@ import UIKit
 
 final class DisabledVideoView: BaseView {
 
+    private(set) var tapGestureRecognizer = UITapGestureRecognizer()
     private let babyLogoView: UIImageView = {
         let view = UIImageView(image: #imageLiteral(resourceName: "childPurple"))
         view.contentMode = .scaleAspectFit
@@ -33,6 +34,7 @@ final class DisabledVideoView: BaseView {
             addSubview($0)
         }
         setupConstraints()
+        addGestureRecognizer(tapGestureRecognizer)
     }
 
     private func setupConstraints() {

--- a/Baby Monitor/Source Files/Custom Views/DisabledVideoView.swift
+++ b/Baby Monitor/Source Files/Custom Views/DisabledVideoView.swift
@@ -8,6 +8,7 @@ import UIKit
 final class DisabledVideoView: BaseView {
 
     private(set) var tapGestureRecognizer = UITapGestureRecognizer()
+
     private let babyLogoView: UIImageView = {
         let view = UIImageView(image: #imageLiteral(resourceName: "childPurple"))
         view.contentMode = .scaleAspectFit
@@ -33,8 +34,8 @@ final class DisabledVideoView: BaseView {
         [babyLogoView, descriptionLabel].forEach {
             addSubview($0)
         }
-        setupConstraints()
         addGestureRecognizer(tapGestureRecognizer)
+        setupConstraints()
     }
 
     private func setupConstraints() {
@@ -44,7 +45,6 @@ final class DisabledVideoView: BaseView {
             $0.equalConstant(.height, 120)
         ]
         }
-
         descriptionLabel.addConstraints {[
             $0.equal(.centerX),
             $0.equalTo(babyLogoView, .top, .bottom, constant: 25),

--- a/Baby Monitor/Source Files/Localizations/Localizable.swift
+++ b/Baby Monitor/Source Files/Localizations/Localizable.swift
@@ -191,6 +191,10 @@ enum Localizable {
         static let unableToFind = localized("errors.message.unable-to-find")
         static let notificationsNotAllowed = localized("errors.notifications-not-allowed")
     }
+
+    enum Video {
+        static let videoDisabledDescription = localized("video.disabled.description")
+    }
 }
 
 private func localized(_ value: String) -> String {

--- a/Baby Monitor/Source Files/Localizations/en.lproj/Localizable.strings
+++ b/Baby Monitor/Source Files/Localizations/en.lproj/Localizable.strings
@@ -152,3 +152,6 @@
 "errors.title.error-occured" = "Error occured";
 "errors.message.unable-to-find" = "Unable to find a device for connection";
 "errors.notifications-not-allowed" = "Notifications are not allowed. You won't get any message if your baby starts crying";
+
+//MARK: - Video Stream
+"video.disabled.description" = "Video preview disabled to conserve energy. Tap to enable it.";

--- a/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
+++ b/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
@@ -135,7 +135,7 @@ final class ServerViewController: BaseViewController {
     }
 
     private func fireVideoTimer() {
-        videoTimer = Observable<Int>.interval(Constants.videoStreamingHiddenAfterTime,
+        videoTimer = Observable<Int>.interval(Constants.videoStreamVisibilityTimeLimit,
                                               scheduler: MainScheduler.instance)
             .startWith(0)
     }

--- a/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
+++ b/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
@@ -45,8 +45,11 @@ final class ServerViewController: BaseViewController {
         target: nil,
         action: nil)
     private var timer: Timer?
+    /// A timer for hiding video stream from view.
+    private var videoTimer: Observable<Int>?
     private let babyNavigationItemView = BabyNavigationItemView(mode: .baby)
     private let localView = StreamVideoView(contentTransform: .flippedHorizontally)
+    private let disabledVideoView = DisabledVideoView()
     private let viewModel: ServerViewModel
     private let bag = DisposeBag()
     
@@ -58,7 +61,7 @@ final class ServerViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupViewModel()
+        setupBindings()
         viewModel.settingsTap = settingsBarButtonItem.rx.tap.asObservable()
         navigationController?.setNavigationBarHidden(false, animated: false)
         timer = Timer.scheduledTimer(withTimeInterval: 0.8, repeats: true, block: { [weak self] _ in
@@ -80,7 +83,7 @@ final class ServerViewController: BaseViewController {
     }
 
     private func setupView() {
-        [localView, buttonsStackView, nightModeOverlay].forEach(view.addSubview)
+        [disabledVideoView, localView, buttonsStackView, nightModeOverlay].forEach(view.addSubview)
         localView.addConstraints { $0.equalEdges() }
         nightModeOverlay.addConstraints { $0.equalEdges() }
 
@@ -89,22 +92,35 @@ final class ServerViewController: BaseViewController {
         buttonsStackView.addConstraints {[
             $0.equal(.safeAreaBottom, constant: -52),
             $0.equal(.centerX)
-        ]}
-
+        ]
+        }
         view.bringSubviewToFront(nightModeOverlay)
         view.bringSubviewToFront(buttonsStackView)
     }
     
-    private func setupViewModel() {
+    private func setupBindings() {
         viewModel.stream
             .subscribe(onNext: { [unowned self] stream in
                 self.attach(stream: stream)
             })
             .disposed(by: bag)
         viewModel.startStreaming()
+        fireVideoTimer()
+        videoTimer?.skip(1).subscribe(onNext: { [weak self] _ in
+            self?.localView.isHidden = true
+            self?.videoTimer = nil
+        })
+        .disposed(by: bag)
         nightModeButton.rx.tap.asObservable().subscribe(onNext: { [weak self] _ in
             guard let self = self else { return }
             self.nightModeOverlay.isHidden.toggle()
+        })
+        .disposed(by: bag)
+        disabledVideoView.tapGestureRecognizer
+            .rx.event
+            .subscribe(onNext: { [weak self] _ in
+                self?.localView.isHidden = false
+                self?.fireVideoTimer()
         })
         .disposed(by: bag)
     }
@@ -116,5 +132,11 @@ final class ServerViewController: BaseViewController {
         localVideoTrack?.remove(localView)
         localVideoTrack = stream.videoTracks[0] as? RTCVideoTrack
         localVideoTrack?.add(localView)
+    }
+
+    private func fireVideoTimer() {
+        videoTimer = Observable<Int>.interval(Constants.videoStreamingHiddenAfterTime,
+                                              scheduler: MainScheduler.instance)
+            .startWith(0)
     }
 }

--- a/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
+++ b/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
@@ -106,7 +106,7 @@ final class ServerViewController: BaseViewController {
             .disposed(by: bag)
         viewModel.startStreaming()
         fireVideoTimer()
-        videoTimer?.skip(1).subscribe(onNext: { [weak self] _ in
+        videoTimer?.subscribe(onNext: { [weak self] _ in
             self?.localView.isHidden = true
             self?.videoTimer = nil
         })
@@ -137,6 +137,5 @@ final class ServerViewController: BaseViewController {
     private func fireVideoTimer() {
         videoTimer = Observable<Int>.interval(Constants.videoStreamVisibilityTimeLimit,
                                               scheduler: MainScheduler.instance)
-            .startWith(0)
     }
 }


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-502
 
### Task Description
<!-- What should and what actually happens. -->
 Baby device on iOS is disabling the video preview after 60 seconds of inactivity.