### PR TITLE
[BM-552] Device is not detected on iOS 13

### DIFF
--- a/Baby Monitor/Source Files/Modules/Onboarding/Pairing/OnboardingPairingCoordinator.swift
+++ b/Baby Monitor/Source Files/Modules/Onboarding/Pairing/OnboardingPairingCoordinator.swift
@@ -33,6 +33,7 @@ final class OnboardingPairingCoordinator: Coordinator {
         let viewController = prepareContinuableViewController(role: role)
         switch role {
         case .parent(.error):
+            viewController.modalPresentationStyle = .fullScreen
             navigationController.present(viewController, animated: true, completion: nil)
         default:
             navigationController.pushViewController(viewController, animated: true)


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-552
 
### Task Description
<!-- What should and what actually happens. -->
 Fixed infinite search for the baby device on the parent device for iOS 13.