### PR TITLE
[BM-552] Device is not detected on iOS 13

### DIFF
--- a/Baby Monitor/Source Files/Services/NetService/NetServiceClient.swift
+++ b/Baby Monitor/Source Files/Services/NetService/NetServiceClient.swift
@@ -81,6 +81,8 @@ final class NetServiceClient: NSObject, NetServiceClientProtocol {
 extension NetServiceClient: NetServiceBrowserDelegate {
 
     func netServiceBrowser(_ browser: NetServiceBrowser, didFind service: NetService, moreComing: Bool) {
+        guard service.name == Constants.netServiceName else { return }
+        netServiceBrowser.stop()
         netService = service
         netService!.delegate = self
         netService!.resolve(withTimeout: 5)


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-552
 
### Task Description
<!-- What should and what actually happens. -->
 Fix looking for devices after the baby device was already found.
