### PR TITLE
[BM-562] Notifications come to the parent device after the reset

### DIFF
--- a/Baby Monitor/Source Files/AppDependencies.swift
+++ b/Baby Monitor/Source Files/AppDependencies.swift
@@ -109,7 +109,7 @@ final class AppDependencies {
     
     // MARK: - Notifications
     
-    private(set) lazy var localNotificationService: NotificationServiceProtocol = NotificationService(
+    fileprivate(set) lazy var localNotificationService: NotificationServiceProtocol = NotificationService(
         networkDispatcher: networkDispatcher,
         serverKeyObtainable: serverKeyObtainable)
     
@@ -169,6 +169,7 @@ extension AppDependencies {
             messageServer.send(message: resetEventString)
         case .parent:
             webSocketEventMessageService.get().sendMessage(resetEventString)
+            localNotificationService.resetTokens(completion: { _ in })
         case .none:
             break
         }
@@ -176,6 +177,8 @@ extension AppDependencies {
         memoryCleaner.cleanMemory()
         urlConfiguration.url = nil
         webSocketWebRtcService.get().close()
+        UserDefaults.selfPushNotificationsToken = ""
+        UserDefaults.receiverPushNotificationsToken = nil
         UserDefaults.appMode = .none
         UserDefaults.isSendingCryingsAllowed = false
         try? AudioKit.stop()

--- a/Baby Monitor/Source Files/AppDependencies.swift
+++ b/Baby Monitor/Source Files/AppDependencies.swift
@@ -109,7 +109,7 @@ final class AppDependencies {
     
     // MARK: - Notifications
     
-    fileprivate(set) lazy var localNotificationService: NotificationServiceProtocol = NotificationService(
+    private(set) lazy var localNotificationService: NotificationServiceProtocol = NotificationService(
         networkDispatcher: networkDispatcher,
         serverKeyObtainable: serverKeyObtainable)
     

--- a/Baby Monitor/Source Files/Services/Notifications/NotificationService.swift
+++ b/Baby Monitor/Source Files/Services/Notifications/NotificationService.swift
@@ -4,10 +4,12 @@
 //
  
 import UserNotifications
+import FirebaseInstanceID
 
 protocol NotificationServiceProtocol: AnyObject {
     func sendPushNotificationsRequest()
     func getNotificationsAllowance(completion: @escaping (Bool) -> Void)
+    func resetTokens(completion: @escaping (Error?) -> Void)
 }
 
 final class NotificationService: NotificationServiceProtocol {
@@ -35,5 +37,11 @@ final class NotificationService: NotificationServiceProtocol {
             serverKey: serverKeyObtainable.serverKey)
         .asURLRequest()
         networkDispatcher.execute(urlRequest: firebasePushNotificationsRequest, completion: nil)
+    }
+
+    func resetTokens(completion: @escaping (Error?) -> Void) {
+        InstanceID.instanceID().deleteID { error in
+            completion(error)
+        }
     }
 }


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-562
 
### Task Description
<!-- What should and what actually happens. -->
 Notifications now shouldn't come as we are resetting all the tokens completely on reset.
