### PR TITLE
[BM-584] Latest activity screen doesn't show notifications

### DIFF
--- a/Baby Monitor/Source Files/AppDelegate.swift
+++ b/Baby Monitor/Source Files/AppDelegate.swift
@@ -54,7 +54,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        appDependencies.databaseRepository.save(activityLogEvent: ActivityLogEvent(mode: .cryingEvent))
+        appDependencies.databaseRepository.save(activityLogEvent: ActivityLogEvent(mode: .cryingEvent), completion: { _ in
+            completionHandler(.noData)
+        })
     }
 }
 

--- a/Baby Monitor/Source Files/AppDelegate.swift
+++ b/Baby Monitor/Source Files/AppDelegate.swift
@@ -54,6 +54,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        guard application.applicationState != .active else {
+            completionHandler(.noData)
+            return
+        }
         appDependencies.databaseRepository.save(activityLogEvent: ActivityLogEvent(mode: .cryingEvent), completion: { _ in
             completionHandler(.noData)
         })
@@ -70,6 +74,9 @@ extension AppDelegate: MessagingDelegate {
 extension AppDelegate: UNUserNotificationCenterDelegate {
     
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        completionHandler([.alert, .sound, .badge])
+        appDependencies.databaseRepository.save(activityLogEvent: ActivityLogEvent(mode: .cryingEvent), completion: { _ in
+            print("notify will present saved")
+            completionHandler([.alert, .sound, .badge])
+        })
     }
 }

--- a/Baby Monitor/Source Files/AppDelegate.swift
+++ b/Baby Monitor/Source Files/AppDelegate.swift
@@ -75,7 +75,6 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         appDependencies.databaseRepository.save(activityLogEvent: ActivityLogEvent(mode: .cryingEvent), completion: { _ in
-            print("notify will present saved")
             completionHandler([.alert, .sound, .badge])
         })
     }

--- a/Baby Monitor/Source Files/Modules/Onboarding/ClientSetupOnboardingViewModel.swift
+++ b/Baby Monitor/Source Files/Modules/Onboarding/ClientSetupOnboardingViewModel.swift
@@ -100,6 +100,6 @@ final class ClientSetupOnboardingViewModel {
             return
         }
         let emptyStateLogEvent = ActivityLogEvent(mode: .emptyState)
-        activityLogEventsRepository.save(activityLogEvent: emptyStateLogEvent)
+        activityLogEventsRepository.save(activityLogEvent: emptyStateLogEvent, completion: { _ in })
     }
 }

--- a/Baby Monitor/Source Files/Services/Persistence/ActivityLogEventsRepositoryProtocol.swift
+++ b/Baby Monitor/Source Files/Services/Persistence/ActivityLogEventsRepositoryProtocol.swift
@@ -14,7 +14,7 @@ protocol ActivityLogEventsRepositoryProtocol: Any {
     /// Persists activity log event in repository for current baby
     ///
     /// - Parameter cryingEvent: object to persist
-    func save(activityLogEvent: ActivityLogEvent, completion: @escaping ((_ isSavedSuccessfully: Bool) -> Void))
+    func save(activityLogEvent: ActivityLogEvent, completion: @escaping (Result<()>) -> Void)
     
     /// Returns all persisted activity log events
     ///

--- a/Baby Monitor/Source Files/Services/Persistence/ActivityLogEventsRepositoryProtocol.swift
+++ b/Baby Monitor/Source Files/Services/Persistence/ActivityLogEventsRepositoryProtocol.swift
@@ -14,7 +14,7 @@ protocol ActivityLogEventsRepositoryProtocol: Any {
     /// Persists activity log event in repository for current baby
     ///
     /// - Parameter cryingEvent: object to persist
-    func save(activityLogEvent: ActivityLogEvent)
+    func save(activityLogEvent: ActivityLogEvent, completion: @escaping ((_ isSavedSuccessfully: Bool) -> Void))
     
     /// Returns all persisted activity log events
     ///

--- a/Baby Monitor/Source Files/Services/Persistence/RealmBabiesRepository.swift
+++ b/Baby Monitor/Source Files/Services/Persistence/RealmBabiesRepository.swift
@@ -25,17 +25,17 @@ final class RealmBabiesRepository: BabyModelControllerProtocol & ActivityLogEven
         setup()
     }
     
-    func save(activityLogEvent: ActivityLogEvent, completion: @escaping ((_ isSavedSuccessfully: Bool) -> Void)) {
+    func save(activityLogEvent: ActivityLogEvent, completion: @escaping (Result<()>) -> Void) {
         DispatchQueue.main.async {
             let realmActivityLogEvent = RealmActivityLogEvent(with: activityLogEvent)
             do {
                 try self.realm.write {
                     self.realm.create(RealmActivityLogEvent.self, value: realmActivityLogEvent, update: .error)
                     self.activityLogEventsPublisher.value.append(activityLogEvent)
-                    completion(true)
+                    completion(.success(()))
                 }
             } catch {
-                completion(false)
+                completion(.failure(error))
             }
         }
     }

--- a/Baby Monitor/Source Files/Services/Persistence/RealmBabiesRepository.swift
+++ b/Baby Monitor/Source Files/Services/Persistence/RealmBabiesRepository.swift
@@ -25,12 +25,17 @@ final class RealmBabiesRepository: BabyModelControllerProtocol & ActivityLogEven
         setup()
     }
     
-    func save(activityLogEvent: ActivityLogEvent) {
+    func save(activityLogEvent: ActivityLogEvent, completion: @escaping ((_ isSavedSuccessfully: Bool) -> Void)) {
         DispatchQueue.main.async {
             let realmActivityLogEvent = RealmActivityLogEvent(with: activityLogEvent)
-            try! self.realm.write {
-                self.realm.create(RealmActivityLogEvent.self, value: realmActivityLogEvent, update: .error)
-                self.activityLogEventsPublisher.value.append(activityLogEvent)
+            do {
+                try self.realm.write {
+                    self.realm.create(RealmActivityLogEvent.self, value: realmActivityLogEvent, update: .error)
+                    self.activityLogEventsPublisher.value.append(activityLogEvent)
+                    completion(true)
+                }
+            } catch {
+                completion(false)
             }
         }
     }

--- a/Baby Monitor/Supporting Files/Info.plist
+++ b/Baby Monitor/Supporting Files/Info.plist
@@ -37,9 +37,7 @@
 		<string>Rubik-Bold.ttf</string>
 	</array>
 	<key>UIBackgroundModes</key>
-	<array>
-		<string>remote-notification</string>
-	</array>
+	<array/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Baby MonitorTests/Mocks/DatabaseRepositoryMock.swift
+++ b/Baby MonitorTests/Mocks/DatabaseRepositoryMock.swift
@@ -47,9 +47,10 @@ final class DatabaseRepositoryMock: BabyModelControllerProtocol & ActivityLogEve
         babyUpdatePublisher.onNext(baby)
     }
     
-    func save(activityLogEvent: ActivityLogEvent) {
+    func save(activityLogEvent: ActivityLogEvent, completion: @escaping (Result<()>) -> Void) {
         activityLogEvents.append(activityLogEvent)
         activityLogEventsPublisher.onNext(activityLogEvents)
+        completion(.success(()))
     }
     
     func fetchAllActivityLogEvents() -> [ActivityLogEvent] {

--- a/Baby MonitorTests/Modules/ActivityLog/ActivityLogViewModelTests.swift
+++ b/Baby MonitorTests/Modules/ActivityLog/ActivityLogViewModelTests.swift
@@ -41,10 +41,10 @@ class ActivityLogViewModelTests: XCTestCase {
             .disposed(by: disposeBag)
         // When
         
-        babiesRepository.save(activityLogEvent: yesterdayCryingLogEvent)
-        babiesRepository.save(activityLogEvent: secondYesterdayCryingLogEvent)
-        babiesRepository.save(activityLogEvent: todayCryingLogEvent)
-        babiesRepository.save(activityLogEvent: tommorowCryingLogEvent)
+        babiesRepository.save(activityLogEvent: yesterdayCryingLogEvent, completion: { _ in })
+        babiesRepository.save(activityLogEvent: secondYesterdayCryingLogEvent, completion: { _ in })
+        babiesRepository.save(activityLogEvent: todayCryingLogEvent, completion: { _ in })
+        babiesRepository.save(activityLogEvent: tommorowCryingLogEvent, completion: { _ in })
         
         // Then
         XCTAssertEqual(expectedSections, resultSections)


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-584 
 
### Task Description
<!-- What should and what actually happens. -->
 The latest activity screen contained only information about devices being paired. Now it contains also info about baby crying events. It writes to DB when the notification came in foreground mode or when user clicked on notifications from the background. In the future, maybe some other solution will be introduced so that all notifications would be recorded.
