### PR TITLE
[BM-558] Improve battery saving with refactoring WebRTC logic

### DIFF
--- a/Baby Monitor.xcodeproj/project.pbxproj
+++ b/Baby Monitor.xcodeproj/project.pbxproj
@@ -202,6 +202,8 @@
 		8AFAE5C6219C205F007013BC /* WebRtcMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFAE5C5219C205F007013BC /* WebRtcMessage.swift */; };
 		8AFAE5CC219C240C007013BC /* Dictionary+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFAE5CB219C240C007013BC /* Dictionary+JSON.swift */; };
 		8AFE3DFB2182F68000729615 /* AnyBabyMonitorGeneralViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFE3DFA2182F68000729615 /* AnyBabyMonitorGeneralViewModelProtocol.swift */; };
+		952A637A238DBC2900C3837A /* VideoCapturerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952A6379238DBC2900C3837A /* VideoCapturerMock.swift */; };
+		952A637C238DBCF300C3837A /* WebRtcVideoCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952A637B238DBCF300C3837A /* WebRtcVideoCapturer.swift */; };
 		95368F522209BC36006E263A /* SpecifyDeviceInfoOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95368F512209BC36006E263A /* SpecifyDeviceInfoOnboardingViewController.swift */; };
 		95368F552209BC6A006E263A /* SpecifyDeviceInfoOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95368F542209BC6A006E263A /* SpecifyDeviceInfoOnboardingView.swift */; };
 		95368F582209BCC6006E263A /* SpecifyDeviceInfoOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95368F572209BCC6006E263A /* SpecifyDeviceInfoOnboardingViewModel.swift */; };
@@ -506,6 +508,8 @@
 		8AFAE5C5219C205F007013BC /* WebRtcMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRtcMessage.swift; sourceTree = "<group>"; };
 		8AFAE5CB219C240C007013BC /* Dictionary+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+JSON.swift"; sourceTree = "<group>"; };
 		8AFE3DFA2182F68000729615 /* AnyBabyMonitorGeneralViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyBabyMonitorGeneralViewModelProtocol.swift; sourceTree = "<group>"; };
+		952A6379238DBC2900C3837A /* VideoCapturerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCapturerMock.swift; sourceTree = "<group>"; };
+		952A637B238DBCF300C3837A /* WebRtcVideoCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRtcVideoCapturer.swift; sourceTree = "<group>"; };
 		95368F512209BC36006E263A /* SpecifyDeviceInfoOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyDeviceInfoOnboardingViewController.swift; sourceTree = "<group>"; };
 		95368F542209BC6A006E263A /* SpecifyDeviceInfoOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyDeviceInfoOnboardingView.swift; sourceTree = "<group>"; };
 		95368F572209BCC6006E263A /* SpecifyDeviceInfoOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyDeviceInfoOnboardingViewModel.swift; sourceTree = "<group>"; };
@@ -1044,6 +1048,7 @@
 				A1B57ACE22E992C20021B314 /* MicrophonePermissionProviderMock.swift */,
 				8A03503023684E6B00CF88C7 /* AsyncSchedulerMock.swift */,
 				9557FA6C237034F7002C9483 /* ServerErrorLoggerMock.swift */,
+				952A6379238DBC2900C3837A /* VideoCapturerMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1153,6 +1158,7 @@
 				8A7A60D121A416E300488ED4 /* WebRtcClientManagerProtocol.swift */,
 				4E55435721D4C33A005C41FD /* WebRtcClientManager.swift */,
 				8A7A612D21A5A35300488ED4 /* WebRtcServerManagerProtocol.swift */,
+				952A637B238DBCF300C3837A /* WebRtcVideoCapturer.swift */,
 				4E55435821D4C33A005C41FD /* WebRtcServerManager.swift */,
 				8A50AA3D21E603080058C63A /* WebRtcConstraintKey.swift */,
 				8A50AA3E21E603080058C63A /* WebRtcStreamId.swift */,
@@ -1765,6 +1771,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				952A637C238DBCF300C3837A /* WebRtcVideoCapturer.swift in Sources */,
 				8A6098C421EBFDA700592B01 /* PeerConnectionFactoryProtocol.swift in Sources */,
 				4E7B091321E6148600EDDD11 /* URLSessionProtocol.swift in Sources */,
 				A1A708C322F320970058B537 /* Bundle+BuildNumber.swift in Sources */,
@@ -1990,6 +1997,7 @@
 				8AFAE5B8219AFF6D007013BC /* WebSocketMock.swift in Sources */,
 				8A50AA8E21E8D8FA0058C63A /* WebRtcClientManagerTests.swift in Sources */,
 				3ABC41B922553FE700645ADA /* MicrophoneRecordMock.swift in Sources */,
+				952A637A238DBC2900C3837A /* VideoCapturerMock.swift in Sources */,
 				8AA7CBCC21871B3E00FCF62A /* ConnectionCheckerMock.swift in Sources */,
 				8A8EF955219D581D0098A27B /* MessageStreamMock.swift in Sources */,
 				8AA7CBC02187105600FCF62A /* BabyMonitorCellMock.swift in Sources */,

--- a/Baby Monitor.xcodeproj/project.pbxproj
+++ b/Baby Monitor.xcodeproj/project.pbxproj
@@ -131,7 +131,6 @@
 		8A50AA9D21E8DBA20058C63A /* WebRtcClientManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A50AA9321E8DBA10058C63A /* WebRtcClientManagerMock.swift */; };
 		8A50AA9E21E8DBA20058C63A /* WebRtcServerManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A50AA9421E8DBA10058C63A /* WebRtcServerManagerMock.swift */; };
 		8A50AA9F21E8DBA20058C63A /* SdpOfferDecoderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A50AA9521E8DBA10058C63A /* SdpOfferDecoderMock.swift */; };
-		8A50AAA021E8DBA20058C63A /* VideoCapturerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A50AA9621E8DBA10058C63A /* VideoCapturerMock.swift */; };
 		8A50AAA121E8DBA20058C63A /* IceCandidateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A50AA9721E8DBA10058C63A /* IceCandidateMock.swift */; };
 		8A50AAA221E8DBA20058C63A /* SdpAnswerDecoderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A50AA9821E8DBA10058C63A /* SdpAnswerDecoderMock.swift */; };
 		8A50AAA321E8DBA20058C63A /* SessionDescriptionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A50AA9921E8DBA20058C63A /* SessionDescriptionMock.swift */; };
@@ -433,7 +432,6 @@
 		8A50AA9321E8DBA10058C63A /* WebRtcClientManagerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebRtcClientManagerMock.swift; sourceTree = "<group>"; };
 		8A50AA9421E8DBA10058C63A /* WebRtcServerManagerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebRtcServerManagerMock.swift; sourceTree = "<group>"; };
 		8A50AA9521E8DBA10058C63A /* SdpOfferDecoderMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SdpOfferDecoderMock.swift; sourceTree = "<group>"; };
-		8A50AA9621E8DBA10058C63A /* VideoCapturerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoCapturerMock.swift; sourceTree = "<group>"; };
 		8A50AA9721E8DBA10058C63A /* IceCandidateMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IceCandidateMock.swift; sourceTree = "<group>"; };
 		8A50AA9821E8DBA10058C63A /* SdpAnswerDecoderMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SdpAnswerDecoderMock.swift; sourceTree = "<group>"; };
 		8A50AA9921E8DBA20058C63A /* SessionDescriptionMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionDescriptionMock.swift; sourceTree = "<group>"; };
@@ -1017,7 +1015,6 @@
 				8A50AA9821E8DBA10058C63A /* SdpAnswerDecoderMock.swift */,
 				8A50AA9521E8DBA10058C63A /* SdpOfferDecoderMock.swift */,
 				8A50AA9921E8DBA20058C63A /* SessionDescriptionMock.swift */,
-				8A50AA9621E8DBA10058C63A /* VideoCapturerMock.swift */,
 				8A50AA9321E8DBA10058C63A /* WebRtcClientManagerMock.swift */,
 				8A50AA9421E8DBA10058C63A /* WebRtcServerManagerMock.swift */,
 				8A7A614521A6AC7900488ED4 /* AudioMicrophoneServiceMock.swift */,
@@ -1985,7 +1982,6 @@
 				8A42DB192179E0AD00BF5F1B /* URLConfigurationMock.swift in Sources */,
 				8A42DAFE2179BFBF00BF5F1B /* ClientSetupViewModelTests.swift in Sources */,
 				A1B57ACF22E992C20021B314 /* MicrophonePermissionProviderMock.swift in Sources */,
-				8A50AAA021E8DBA20058C63A /* VideoCapturerMock.swift in Sources */,
 				8A7A60CE21A40D3B00488ED4 /* MicrophoneTrackerMock.swift in Sources */,
 				8A6098C021EBFB1F00592B01 /* PeerConnectionFactoryMock.swift in Sources */,
 				3ABC41BB2255407100645ADA /* MicrophoneCaptureMock.swift in Sources */,

--- a/Baby Monitor.xcodeproj/project.pbxproj
+++ b/Baby Monitor.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		8AFE3DFB2182F68000729615 /* AnyBabyMonitorGeneralViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFE3DFA2182F68000729615 /* AnyBabyMonitorGeneralViewModelProtocol.swift */; };
 		952A637A238DBC2900C3837A /* VideoCapturerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952A6379238DBC2900C3837A /* VideoCapturerMock.swift */; };
 		952A637C238DBCF300C3837A /* WebRtcVideoCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952A637B238DBCF300C3837A /* WebRtcVideoCapturer.swift */; };
+		952A6388238DE31F00C3837A /* PeerConnectionProxyMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952A6387238DE31F00C3837A /* PeerConnectionProxyMock.swift */; };
 		95368F522209BC36006E263A /* SpecifyDeviceInfoOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95368F512209BC36006E263A /* SpecifyDeviceInfoOnboardingViewController.swift */; };
 		95368F552209BC6A006E263A /* SpecifyDeviceInfoOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95368F542209BC6A006E263A /* SpecifyDeviceInfoOnboardingView.swift */; };
 		95368F582209BCC6006E263A /* SpecifyDeviceInfoOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95368F572209BCC6006E263A /* SpecifyDeviceInfoOnboardingViewModel.swift */; };
@@ -510,6 +511,7 @@
 		8AFE3DFA2182F68000729615 /* AnyBabyMonitorGeneralViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyBabyMonitorGeneralViewModelProtocol.swift; sourceTree = "<group>"; };
 		952A6379238DBC2900C3837A /* VideoCapturerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCapturerMock.swift; sourceTree = "<group>"; };
 		952A637B238DBCF300C3837A /* WebRtcVideoCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRtcVideoCapturer.swift; sourceTree = "<group>"; };
+		952A6387238DE31F00C3837A /* PeerConnectionProxyMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeerConnectionProxyMock.swift; sourceTree = "<group>"; };
 		95368F512209BC36006E263A /* SpecifyDeviceInfoOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyDeviceInfoOnboardingViewController.swift; sourceTree = "<group>"; };
 		95368F542209BC6A006E263A /* SpecifyDeviceInfoOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyDeviceInfoOnboardingView.swift; sourceTree = "<group>"; };
 		95368F572209BCC6006E263A /* SpecifyDeviceInfoOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyDeviceInfoOnboardingViewModel.swift; sourceTree = "<group>"; };
@@ -1033,6 +1035,7 @@
 				8AA7CBCB21871B3E00FCF62A /* ConnectionCheckerMock.swift */,
 				8AA7CBE3218C5A5100FCF62A /* URLMediaPlayerMock.swift */,
 				8AFAE5B4219ACA5F007013BC /* WebSocketServerMock.swift */,
+				952A6387238DE31F00C3837A /* PeerConnectionProxyMock.swift */,
 				8AFAE5B7219AFF6D007013BC /* WebSocketMock.swift */,
 				8AFAE5BD219C0FF7007013BC /* MessageDecoderMock.swift */,
 				8A8EF954219D581D0098A27B /* MessageStreamMock.swift */,
@@ -2002,6 +2005,7 @@
 				8A8EF955219D581D0098A27B /* MessageStreamMock.swift in Sources */,
 				8AA7CBC02187105600FCF62A /* BabyMonitorCellMock.swift in Sources */,
 				8AA7CBCA21871AE300FCF62A /* DashboardViewModelTests.swift in Sources */,
+				952A6388238DE31F00C3837A /* PeerConnectionProxyMock.swift in Sources */,
 				8A7A614A21A6AC7900488ED4 /* AudioMicrophoneServiceMock.swift in Sources */,
 				8A42DB0E2179D8FB00BF5F1B /* URLUserDefaultsMock.swift in Sources */,
 				8A7A614921A6AC7900488ED4 /* CryingDetectionServiceMock.swift in Sources */,

--- a/Baby Monitor/Resources/Constants.swift
+++ b/Baby Monitor/Resources/Constants.swift
@@ -18,7 +18,7 @@ enum Constants {
     static let notificationRequestTimeLimit: TimeInterval = 3 * 60
 
     /// A time after which the video stream should be hidden.
-    static let videoStreamVisibilityTimeLimit: TimeInterval = 60
+    static let videoStreamVisibilityTimeLimit: TimeInterval = 15
 
     /// A limit for searching for a baby device to be paired to.
     static let pairingDeviceSearchTimeLimit: TimeInterval = 2 * 60

--- a/Baby Monitor/Resources/Constants.swift
+++ b/Baby Monitor/Resources/Constants.swift
@@ -18,7 +18,7 @@ enum Constants {
     static let notificationRequestTimeLimit: TimeInterval = 3 * 60
 
     /// A time after which the video stream should be hidden.
-    static let videoStreamVisibilityTimeLimit: TimeInterval = 15
+    static let videoStreamVisibilityTimeLimit: TimeInterval = 60
 
     /// A limit for searching for a baby device to be paired to.
     static let pairingDeviceSearchTimeLimit: TimeInterval = 2 * 60

--- a/Baby Monitor/Source Files/AppDependencies.swift
+++ b/Baby Monitor/Source Files/AppDependencies.swift
@@ -28,9 +28,7 @@ final class AppDependencies {
         storageService: storageServerService)
     
     /// Service for capturing/recording microphone audio
-    private(set) lazy var audioMicrophoneService: AudioMicrophoneServiceProtocol? =
-//    nil
-        try? AudioMicrophoneService(microphoneFactory: AudioKitMicrophoneFactory.makeMicrophoneFactory)
+    private(set) lazy var audioMicrophoneService: AudioMicrophoneServiceProtocol? = try? AudioMicrophoneService(microphoneFactory: AudioKitMicrophoneFactory.makeMicrophoneFactory)
     
     let microphonePermissionProvider: MicrophonePermissionProviderProtocol = MicrophonePermissionProvider()
     

--- a/Baby Monitor/Source Files/AppDependencies.swift
+++ b/Baby Monitor/Source Files/AppDependencies.swift
@@ -41,9 +41,11 @@ final class AppDependencies {
     private(set) lazy var connectionChecker: ConnectionChecker = NetServiceConnectionChecker(netServiceClient: netServiceClient, urlConfiguration: urlConfiguration)
     
     // MARK: - WebRTC
-    
+
+    private(set) lazy var webRtcConnectionProxy: PeerConnectionProxy = RTCPeerConnectionDelegateProxy()
+
     private(set) lazy var webRtcServer: () -> WebRtcServerManagerProtocol = {
-        WebRtcServerManager(peerConnectionFactory: self.peerConnectionFactory)
+        WebRtcServerManager(peerConnectionFactory: self.peerConnectionFactory, connectionDelegateProxy: self.webRtcConnectionProxy)
     }
     
     private(set) lazy var webRtcClient: () -> WebRtcClientManagerProtocol = {

--- a/Baby Monitor/Source Files/AppDependencies.swift
+++ b/Baby Monitor/Source Files/AppDependencies.swift
@@ -28,7 +28,9 @@ final class AppDependencies {
         storageService: storageServerService)
     
     /// Service for capturing/recording microphone audio
-    private(set) lazy var audioMicrophoneService: AudioMicrophoneServiceProtocol? = try? AudioMicrophoneService(microphoneFactory: AudioKitMicrophoneFactory.makeMicrophoneFactory)
+    private(set) lazy var audioMicrophoneService: AudioMicrophoneServiceProtocol? =
+//    nil
+        try? AudioMicrophoneService(microphoneFactory: AudioKitMicrophoneFactory.makeMicrophoneFactory)
     
     let microphonePermissionProvider: MicrophonePermissionProviderProtocol = MicrophonePermissionProvider()
     

--- a/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
+++ b/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
@@ -117,7 +117,6 @@ final class ServerViewController: BaseViewController {
     
     private func setupBindings() {
         viewModel.stream
-//            .observeOn(MainScheduler.instance)
             .subscribe(onNext: { [unowned self] stream in
                 self.attach(stream: stream)
             })

--- a/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
+++ b/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
@@ -124,7 +124,7 @@ final class ServerViewController: BaseViewController {
         viewModel.startStreaming()
         fireVideoTimer()
         videoTimer?.subscribe(onNext: { [weak self] _ in
-            self?.localView.isHidden = true
+            self?.disableVideoStreaming()
             self?.videoTimer = nil
         })
         .disposed(by: bag)
@@ -136,7 +136,7 @@ final class ServerViewController: BaseViewController {
         disabledVideoView.tapGestureRecognizer
             .rx.event
             .subscribe(onNext: { [weak self] _ in
-                self?.localView.isHidden = false
+                self?.enableVideoStreaming()
                 self?.fireVideoTimer()
         })
         .disposed(by: bag)
@@ -155,6 +155,19 @@ final class ServerViewController: BaseViewController {
         localVideoTrack?.remove(localView)
         localVideoTrack = stream.videoTracks[0]
         localVideoTrack?.add(localView)
+    }
+
+    private func enableVideoStreaming() {
+        viewModel.resumeVideoStreaming()
+        localView.isHidden = false
+    }
+
+    private func disableVideoStreaming() {
+        guard localVideoTrack != nil else { return }
+        self.viewModel.pauseVideoStreaming()
+        self.localVideoTrack?.remove(self.localView)
+        self.localVideoTrack = nil
+        self.localView.isHidden = true
     }
 
     private func fireVideoTimer() {

--- a/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
+++ b/Baby Monitor/Source Files/Modules/Server/ServerViewController.swift
@@ -117,6 +117,7 @@ final class ServerViewController: BaseViewController {
     
     private func setupBindings() {
         viewModel.stream
+//            .observeOn(MainScheduler.instance)
             .subscribe(onNext: { [unowned self] stream in
                 self.attach(stream: stream)
             })

--- a/Baby Monitor/Source Files/Modules/Server/ServerViewModel.swift
+++ b/Baby Monitor/Source Files/Modules/Server/ServerViewModel.swift
@@ -33,6 +33,14 @@ final class ServerViewModel {
     func startStreaming() {
         serverService.startStreaming()
     }
+
+    func pauseVideoStreaming() {
+        serverService.pauseVideoStreaming()
+    }
+
+    func resumeVideoStreaming() {
+        serverService.resumeVideoStreaming()
+    }
     
     private func rxSetup() {
         serverService.audioMicrophoneServiceErrorObservable.subscribe(onNext: { [weak self] _ in

--- a/Baby Monitor/Source Files/Services/Connection/WebRTC/RTCPeerConnectionDelegateProxy.swift
+++ b/Baby Monitor/Source Files/Services/Connection/WebRTC/RTCPeerConnectionDelegateProxy.swift
@@ -12,12 +12,17 @@ final class RTCPeerConnectionDelegateProxy: NSObject, RTCPeerConnectionDelegate 
     private var signalingStatePublisher = BehaviorSubject<RTCSignalingState>(value: .closed)
 
     var onSignalingStateChanged: ((RTCPeerConnection, RTCSignalingState) -> Void)?
+    var onConnectionStateChanged: ((RTCPeerConnection, RTCPeerConnectionState) -> Void)?
     var onAddedStream: ((RTCPeerConnection, RTCMediaStream) -> Void)?
     var onGotIceCandidate: ((RTCPeerConnection, RTCIceCandidate) -> Void)?
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCSignalingState) {
         onSignalingStateChanged?(peerConnection, newState)
         signalingStatePublisher.onNext(newState)
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCPeerConnectionState) {
+        onConnectionStateChanged?(peerConnection, newState)
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didAdd stream: RTCMediaStream) {

--- a/Baby Monitor/Source Files/Services/Connection/WebRTC/RTCPeerConnectionDelegateProxy.swift
+++ b/Baby Monitor/Source Files/Services/Connection/WebRTC/RTCPeerConnectionDelegateProxy.swift
@@ -6,13 +6,21 @@
 import RxSwift
 import WebRTC
 
-final class RTCPeerConnectionDelegateProxy: NSObject, RTCPeerConnectionDelegate {
+protocol PeerConnectionProxy: RTCPeerConnectionDelegate {
+    var signalingState: Observable<RTCSignalingState> { get }
+    var onSignalingStateChanged: ((RTCPeerConnection, RTCSignalingState) -> Void)? { get set }
+    var onConnectionStateChanged: ((RTCPeerConnection?, RTCPeerConnectionState) -> Void)? { get set }
+    var onAddedStream: ((RTCPeerConnection, RTCMediaStream) -> Void)? { get set }
+    var onGotIceCandidate: ((RTCPeerConnection, RTCIceCandidate) -> Void)? { get set }
+}
+
+final class RTCPeerConnectionDelegateProxy: NSObject, PeerConnectionProxy {
 
     var signalingState: Observable<RTCSignalingState> { return signalingStatePublisher }
     private var signalingStatePublisher = BehaviorSubject<RTCSignalingState>(value: .closed)
 
     var onSignalingStateChanged: ((RTCPeerConnection, RTCSignalingState) -> Void)?
-    var onConnectionStateChanged: ((RTCPeerConnection, RTCPeerConnectionState) -> Void)?
+    var onConnectionStateChanged: ((RTCPeerConnection?, RTCPeerConnectionState) -> Void)?
     var onAddedStream: ((RTCPeerConnection, RTCMediaStream) -> Void)?
     var onGotIceCandidate: ((RTCPeerConnection, RTCIceCandidate) -> Void)?
 

--- a/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcServerManagerProtocol.swift
+++ b/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcServerManagerProtocol.swift
@@ -13,6 +13,10 @@ protocol WebRtcServerManagerProtocol {
     /// Closes connection
     func stop()
 
+    func pauseMediaStream()
+
+    func resumeMediaStream()
+
     /// Sets session description answer
     ///
     /// - Parameter sdp: session description protocol to add

--- a/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcServerManagerProtocol.swift
+++ b/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcServerManagerProtocol.swift
@@ -13,8 +13,10 @@ protocol WebRtcServerManagerProtocol {
     /// Closes connection
     func stop()
 
+    /// Pauses video streaming.
     func pauseMediaStream()
 
+    /// Resumes video streaming.
     func resumeMediaStream()
 
     /// Sets session description answer

--- a/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcVideoCapturer.swift
+++ b/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcVideoCapturer.swift
@@ -27,7 +27,8 @@ final class WebRTCVideoCapturer: VideoCapturer {
     }
 
     func startCapturing() {
-        capturer.startCapture(with: device, format: format, fps: framesPerSecond) { [weak self] _ in
+        capturer.startCapture(with: device, format: format, fps: framesPerSecond) { [weak self] error in
+            /// The error is error!, so it can be checked whether it actually is there or not. That's why, unfortunatelly, the true value will always be passed.
             self?.isCapturing = true
         }
     }

--- a/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcVideoCapturer.swift
+++ b/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcVideoCapturer.swift
@@ -1,0 +1,27 @@
+//
+//  WebRtcVideoCapturer.swift
+//  Baby Monitor
+//
+
+import WebRTC
+
+protocol VideoCapturer {
+    func resumeCapturing()
+    func stopCapturing()
+}
+
+struct WebRTCVideoCapturer: VideoCapturer {
+
+    private let device: AVCaptureDevice
+    private let format: AVCaptureDevice.Format
+    private let fps: Int
+    private let capturer: RTCCameraVideoCapturer
+
+    func resumeCapturing() {
+        capturer.startCapture(with: device, format: format, fps: fps)
+    }
+
+    func stopCapturing() {
+        capturer.stopCapture()
+    }
+}

--- a/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcVideoCapturer.swift
+++ b/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcVideoCapturer.swift
@@ -6,22 +6,35 @@
 import WebRTC
 
 protocol VideoCapturer {
+    var isCapturing: Bool { get }
     func resumeCapturing()
     func stopCapturing()
 }
 
-struct WebRTCVideoCapturer: VideoCapturer {
+final class WebRTCVideoCapturer: VideoCapturer {
 
+    private(set) var isCapturing = false
     private let device: AVCaptureDevice
     private let format: AVCaptureDevice.Format
-    private let fps: Int
+    private let framesPerSecond: Int
     private let capturer: RTCCameraVideoCapturer
 
+    init(device: AVCaptureDevice, format: AVCaptureDevice.Format, framesPerSecond: Int, capturer: RTCCameraVideoCapturer) {
+        self.device = device
+        self.format = format
+        self.framesPerSecond = framesPerSecond
+        self.capturer = capturer
+    }
+
     func resumeCapturing() {
-        capturer.startCapture(with: device, format: format, fps: fps)
+        capturer.startCapture(with: device, format: format, fps: framesPerSecond) { [weak self] _ in
+            self?.isCapturing = true
+        }
     }
 
     func stopCapturing() {
-        capturer.stopCapture()
+        capturer.stopCapture { [weak self] in
+            self?.isCapturing = false
+        }
     }
 }

--- a/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcVideoCapturer.swift
+++ b/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcVideoCapturer.swift
@@ -7,7 +7,7 @@ import WebRTC
 
 protocol VideoCapturer {
     var isCapturing: Bool { get }
-    func resumeCapturing()
+    func startCapturing()
     func stopCapturing()
 }
 
@@ -26,7 +26,7 @@ final class WebRTCVideoCapturer: VideoCapturer {
         self.capturer = capturer
     }
 
-    func resumeCapturing() {
+    func startCapturing() {
         capturer.startCapture(with: device, format: format, fps: framesPerSecond) { [weak self] _ in
             self?.isCapturing = true
         }

--- a/Baby Monitor/Source Files/Services/ServerService.swift
+++ b/Baby Monitor/Source Files/Services/ServerService.swift
@@ -13,6 +13,8 @@ protocol ServerServiceProtocol: AnyObject {
     var loggingInfoObservable: Observable<String> { get }
     func startStreaming()
     func stop()
+    func pauseVideoStreaming()
+    func resumeVideoStreaming()
 }
 
 final class ServerService: ServerServiceProtocol {
@@ -157,5 +159,13 @@ final class ServerService: ServerServiceProtocol {
             }
         }
         webRtcServerManager.start()
+    }
+
+    func pauseVideoStreaming() {
+        webRtcServerManager.pauseMediaStream()
+    }
+
+    func resumeVideoStreaming() {
+        webRtcServerManager.resumeMediaStream()
     }
 }

--- a/Baby MonitorTests/Mocks/PeerConnectionFactoryMock.swift
+++ b/Baby MonitorTests/Mocks/PeerConnectionFactoryMock.swift
@@ -25,7 +25,7 @@ final class PeerConnectionFactoryMock: PeerConnectionFactoryProtocol {
     }
     
     func createStream() -> (VideoCapturer?, MediaStream?) {
-        videoCapturer?.resumeCapturing()
+        videoCapturer?.startCapturing()
         return (videoCapturer, mediaStream)
     }
 }

--- a/Baby MonitorTests/Mocks/PeerConnectionFactoryMock.swift
+++ b/Baby MonitorTests/Mocks/PeerConnectionFactoryMock.swift
@@ -6,11 +6,6 @@
 @testable import BabyMonitor
 import WebRTC
 
-struct VideoCapturerMock: VideoCapturer {
-    func resumeCapturing() {}
-    func stopCapturing() {}
-}
-
 final class PeerConnectionFactoryMock: PeerConnectionFactoryProtocol {
 
     private let mediaStream: MediaStream?

--- a/Baby MonitorTests/Mocks/PeerConnectionFactoryMock.swift
+++ b/Baby MonitorTests/Mocks/PeerConnectionFactoryMock.swift
@@ -20,7 +20,7 @@ final class PeerConnectionFactoryMock: PeerConnectionFactoryProtocol {
         self.peerConnectionProtocol = peerConnectionProtocol
     }
 
-    func peerConnection(with delegate: RTCPeerConnectionDelegate) -> PeerConnectionProtocol {
+    func peerConnection(with delegate: PeerConnectionProxy) -> PeerConnectionProtocol {
         return peerConnectionProtocol
     }
     

--- a/Baby MonitorTests/Mocks/PeerConnectionFactoryMock.swift
+++ b/Baby MonitorTests/Mocks/PeerConnectionFactoryMock.swift
@@ -8,11 +8,15 @@ import WebRTC
 
 final class PeerConnectionFactoryMock: PeerConnectionFactoryProtocol {
 
+    private let videoCapturer: VideoCapturer?
     private let mediaStream: MediaStream?
     private let peerConnectionProtocol: PeerConnectionProtocol
 
-    init(peerConnectionProtocol: PeerConnectionProtocol, mediaStream: MediaStream? = nil) {
+    init(peerConnectionProtocol: PeerConnectionProtocol,
+         videoCapturer: VideoCapturer? = nil,
+         mediaStream: MediaStream? = nil) {
         self.mediaStream = mediaStream
+        self.videoCapturer = videoCapturer
         self.peerConnectionProtocol = peerConnectionProtocol
     }
 
@@ -21,6 +25,7 @@ final class PeerConnectionFactoryMock: PeerConnectionFactoryProtocol {
     }
     
     func createStream() -> (VideoCapturer?, MediaStream?) {
-        return (VideoCapturerMock(), mediaStream)
+        videoCapturer?.resumeCapturing()
+        return (videoCapturer, mediaStream)
     }
 }

--- a/Baby MonitorTests/Mocks/PeerConnectionFactoryMock.swift
+++ b/Baby MonitorTests/Mocks/PeerConnectionFactoryMock.swift
@@ -6,6 +6,11 @@
 @testable import BabyMonitor
 import WebRTC
 
+struct VideoCapturerMock: VideoCapturer {
+    func resumeCapturing() {}
+    func stopCapturing() {}
+}
+
 final class PeerConnectionFactoryMock: PeerConnectionFactoryProtocol {
 
     private let mediaStream: MediaStream?
@@ -19,7 +24,8 @@ final class PeerConnectionFactoryMock: PeerConnectionFactoryProtocol {
     func peerConnection(with delegate: RTCPeerConnectionDelegate) -> PeerConnectionProtocol {
         return peerConnectionProtocol
     }
+    
     func createStream() -> (VideoCapturer?, MediaStream?) {
-        return ("" as VideoCapturer, mediaStream)
+        return (VideoCapturerMock(), mediaStream)
     }
 }

--- a/Baby MonitorTests/Mocks/PeerConnectionProxyMock.swift
+++ b/Baby MonitorTests/Mocks/PeerConnectionProxyMock.swift
@@ -1,0 +1,49 @@
+//
+//  PeerConnectionProxyMock.swift
+//  Baby MonitorTests
+//
+
+@testable import BabyMonitor
+import WebRTC
+import RxSwift
+
+final class PeerConnectionProxyMock: NSObject, PeerConnectionProxy {
+
+    var signalingState: Observable<RTCSignalingState> { return signalingStatePublisher }
+
+    private var signalingStatePublisher = BehaviorSubject<RTCSignalingState>(value: .closed)
+
+    var onSignalingStateChanged: ((RTCPeerConnection, RTCSignalingState) -> Void)?
+
+    var onConnectionStateChanged: ((RTCPeerConnection?, RTCPeerConnectionState) -> Void)?
+
+    var onAddedStream: ((RTCPeerConnection, RTCMediaStream) -> Void)?
+
+    var onGotIceCandidate: ((RTCPeerConnection, RTCIceCandidate) -> Void)?
+
+    func simulateConnectionState() {
+        onConnectionStateChanged?(nil, RTCPeerConnectionState.connected)
+    }
+
+    func simulateDisconnectedState() {
+        onConnectionStateChanged?(nil, RTCPeerConnectionState.disconnected)
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange stateChanged: RTCSignalingState) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didAdd stream: RTCMediaStream) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didRemove stream: RTCMediaStream) {}
+
+    func peerConnectionShouldNegotiate(_ peerConnection: RTCPeerConnection) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceConnectionState) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceGatheringState) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didGenerate candidate: RTCIceCandidate) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didRemove candidates: [RTCIceCandidate]) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didOpen dataChannel: RTCDataChannel) {}
+}

--- a/Baby MonitorTests/Mocks/VideoCapturerMock.swift
+++ b/Baby MonitorTests/Mocks/VideoCapturerMock.swift
@@ -9,7 +9,7 @@ final class VideoCapturerMock: VideoCapturer {
 
     private(set) var isCapturing = false
 
-    func resumeCapturing() {
+    func startCapturing() {
         isCapturing = true
     }
 

--- a/Baby MonitorTests/Mocks/VideoCapturerMock.swift
+++ b/Baby MonitorTests/Mocks/VideoCapturerMock.swift
@@ -1,6 +1,0 @@
-//
-//  VideoCapturerMock.swift
-//  Baby MonitorTests
-//
-
-class VideoCapturerMock {}

--- a/Baby MonitorTests/Mocks/VideoCapturerMock.swift
+++ b/Baby MonitorTests/Mocks/VideoCapturerMock.swift
@@ -5,7 +5,15 @@
 
 @testable import BabyMonitor
 
-struct VideoCapturerMock: VideoCapturer {
-    func resumeCapturing() {}
-    func stopCapturing() {}
+final class VideoCapturerMock: VideoCapturer {
+
+    private(set) var isCapturing = false
+
+    func resumeCapturing() {
+        isCapturing = true
+    }
+
+    func stopCapturing() {
+        isCapturing = false
+    }
 }

--- a/Baby MonitorTests/Mocks/VideoCapturerMock.swift
+++ b/Baby MonitorTests/Mocks/VideoCapturerMock.swift
@@ -1,0 +1,11 @@
+//
+//  VideoCapturerMock.swift
+//  Baby MonitorTests
+//
+
+@testable import BabyMonitor
+
+struct VideoCapturerMock: VideoCapturer {
+    func resumeCapturing() {}
+    func stopCapturing() {}
+}

--- a/Baby MonitorTests/Mocks/WebRtcServerManagerMock.swift
+++ b/Baby MonitorTests/Mocks/WebRtcServerManagerMock.swift
@@ -7,6 +7,7 @@
 import RxSwift
 
 final class WebRtcServerManagerMock: WebRtcServerManagerProtocol {
+
     private(set) var isStarted = true
     private(set) var remoteSdp: SessionDescriptionProtocol?
     private(set) var iceCandidates = [IceCandidateProtocol]()
@@ -37,6 +38,10 @@ final class WebRtcServerManagerMock: WebRtcServerManagerProtocol {
     func stop() {
         isStarted = false
     }
+
+    func pauseMediaStream() {}
+
+    func resumeMediaStream() {}
 
     var sdpAnswer: Observable<SessionDescriptionProtocol> {
         return sdpAnswerPublisher

--- a/Baby MonitorTests/Networking/WebRTC/WebRtcServerManagerTests.swift
+++ b/Baby MonitorTests/Networking/WebRTC/WebRtcServerManagerTests.swift
@@ -84,6 +84,29 @@ class WebRtcServerManagerTests: XCTestCase {
         XCTAssertEqual([streamId], observer.events.map { ($0.value.element as! String) })
     }
 
+    func testShouldNotEmitStreamWhenNoCapturer() {
+        // Given
+        let bag = DisposeBag()
+        let scheduler = TestScheduler(initialClock: 0)
+        let observer = scheduler.createObserver(MediaStream.self)
+        let peerConnection = PeerConnectionMock()
+        let streamId = "test"
+        let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection,
+                                                              videoCapturer: nil,
+                                                              mediaStream: streamId as MediaStream)
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory, scheduler: AsyncSchedulerMock())
+
+        sut.mediaStream
+            .subscribe(observer)
+            .disposed(by: bag)
+
+        // When
+        sut.start()
+
+        // Then
+        XCTAssertEqual([], observer.events.map { ($0.value.element as! String) })
+    }
+
     func testShouldCaptureStreamAfterStart() {
         // Given
         let videoCapturerMock = VideoCapturerMock()
@@ -158,5 +181,4 @@ class WebRtcServerManagerTests: XCTestCase {
         // Then
         XCTAssertEqual([streamId, streamId], observer.events.map { ($0.value.element as! String) })
     }
-
 }

--- a/Baby MonitorTests/Networking/WebRTC/WebRtcServerManagerTests.swift
+++ b/Baby MonitorTests/Networking/WebRTC/WebRtcServerManagerTests.swift
@@ -15,7 +15,10 @@ class WebRtcServerManagerTests: XCTestCase {
         let sdpOffer = SessionDescriptionMock(sdp: "sdp", stringType: "answer")
         let peerConnection = PeerConnectionMock()
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection)
-        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory, scheduler: AsyncSchedulerMock())
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
 
         // When
         sut.start()
@@ -32,7 +35,10 @@ class WebRtcServerManagerTests: XCTestCase {
         let iceCandidate = IceCandidateMock(sdpMLineIndex: 0, sdpMid: "", sdp: "sdp")
         let peerConnection = PeerConnectionMock()
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection)
-        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory, scheduler: AsyncSchedulerMock())
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
 
         // When
         sut.start()
@@ -48,7 +54,10 @@ class WebRtcServerManagerTests: XCTestCase {
         let sdpOffer = SessionDescriptionMock(sdp: "sdp", stringType: "answer")
         let peerConnection = PeerConnectionMock()
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection)
-        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory, scheduler: AsyncSchedulerMock())
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
 
         // When
         sut.start()
@@ -70,7 +79,10 @@ class WebRtcServerManagerTests: XCTestCase {
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection,
                                                               videoCapturer: videoCapturerMock,
                                                               mediaStream: streamId as MediaStream)
-        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory, scheduler: AsyncSchedulerMock())
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
 
         sut.mediaStream
             .subscribe(observer)
@@ -94,7 +106,10 @@ class WebRtcServerManagerTests: XCTestCase {
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection,
                                                               videoCapturer: nil,
                                                               mediaStream: streamId as MediaStream)
-        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory, scheduler: AsyncSchedulerMock())
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
 
         sut.mediaStream
             .subscribe(observer)
@@ -112,7 +127,10 @@ class WebRtcServerManagerTests: XCTestCase {
         let videoCapturerMock = VideoCapturerMock()
         let peerConnection = PeerConnectionMock()
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection, videoCapturer: videoCapturerMock)
-        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory, scheduler: AsyncSchedulerMock())
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
 
         // When
         sut.start()
@@ -128,7 +146,10 @@ class WebRtcServerManagerTests: XCTestCase {
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection,
                                                               videoCapturer: videoCapturerMock,
                                                               mediaStream: "" as MediaStream)
-        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory, scheduler: AsyncSchedulerMock())
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
 
         // When
         sut.start()
@@ -145,7 +166,10 @@ class WebRtcServerManagerTests: XCTestCase {
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection,
                                                               videoCapturer: videoCapturerMock,
                                                               mediaStream: "" as MediaStream)
-        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory, scheduler: AsyncSchedulerMock())
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
 
         // When
         sut.start()
@@ -167,7 +191,10 @@ class WebRtcServerManagerTests: XCTestCase {
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection,
                                                               videoCapturer: videoCapturerMock,
                                                               mediaStream: streamId as MediaStream)
-        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory, scheduler: AsyncSchedulerMock())
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
 
         sut.mediaStream
             .subscribe(observer)
@@ -180,5 +207,46 @@ class WebRtcServerManagerTests: XCTestCase {
 
         // Then
         XCTAssertEqual([streamId, streamId], observer.events.map { ($0.value.element as! String) })
+    }
+
+    func testShouldNotPauseWhenClientIsConnected() {
+        // Given
+        let videoCapturerMock = VideoCapturerMock()
+        let peerConnection = PeerConnectionMock()
+        let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection,
+                                                              videoCapturer: videoCapturerMock,
+                                                              mediaStream: "" as MediaStream)
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
+
+        // When
+        sut.start()
+        connectionDelegateProxy.simulateConnectionState()
+        sut.pauseMediaStream()
+
+        // Then
+        XCTAssertEqual(videoCapturerMock.isCapturing, true)
+    }
+
+    func testShouldStopCapturingWhenClientDisconnected() {
+        // Given
+        let videoCapturerMock = VideoCapturerMock()
+        let peerConnection = PeerConnectionMock()
+        let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection,
+                                                              videoCapturer: videoCapturerMock,
+                                                              mediaStream: "" as MediaStream)
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
+
+        // When
+        sut.start()
+        connectionDelegateProxy.simulateDisconnectedState()
+
+        // Then
+        XCTAssertEqual(videoCapturerMock.isCapturing, false)
     }
 }

--- a/Dependencies/WebRTC/WebRtcServerManager.swift
+++ b/Dependencies/WebRTC/WebRtcServerManager.swift
@@ -99,8 +99,9 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
 
     func pauseMediaStream() {
         /// If client previews the server stream we shouldn't pause it.
-        guard streamingState == .active && lastConnectionState != .connected else { return }
-        videoCapturer?.stopCapturing()
+        guard let capturer = videoCapturer,
+            streamingState == .active && lastConnectionState != .connected else { return }
+        capturer.stopCapturing()
         streamingState = .paused
     }
 

--- a/Dependencies/WebRTC/WebRtcServerManager.swift
+++ b/Dependencies/WebRTC/WebRtcServerManager.swift
@@ -31,7 +31,7 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
 
     private var peerConnection: PeerConnectionProtocol?
     private let peerConnectionFactory: PeerConnectionFactoryProtocol
-    private let connectionDelegateProxy: RTCPeerConnectionDelegateProxy
+    private let connectionDelegateProxy: PeerConnectionProxy
     private let remoteDescriptionDelegateProxy: RTCSessionDescriptionDelegateProxy
     private let localDescriptionDelegateProxy: RTCSessionDescriptionDelegateProxy
     private let scheduler: AsyncScheduler
@@ -46,9 +46,9 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
         )
     }
 
-    init(peerConnectionFactory: PeerConnectionFactoryProtocol, scheduler: AsyncScheduler = DispatchQueue.main) {
+    init(peerConnectionFactory: PeerConnectionFactoryProtocol, connectionDelegateProxy: PeerConnectionProxy, scheduler: AsyncScheduler = DispatchQueue.main) {
         self.peerConnectionFactory = peerConnectionFactory
-        self.connectionDelegateProxy = RTCPeerConnectionDelegateProxy()
+        self.connectionDelegateProxy = connectionDelegateProxy
         self.remoteDescriptionDelegateProxy = RTCSessionDescriptionDelegateProxy()
         self.localDescriptionDelegateProxy = RTCSessionDescriptionDelegateProxy()
         self.scheduler = scheduler

--- a/Dependencies/WebRTC/WebRtcServerManager.swift
+++ b/Dependencies/WebRTC/WebRtcServerManager.swift
@@ -54,7 +54,6 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
     }
 
     func setup() {
-
         connectionDelegateProxy.onGotIceCandidate = { [weak self] _, iceCandidate in
             guard let self = self else { return }
             self.iceCandidatePublisher.onNext(iceCandidate)
@@ -79,6 +78,14 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
         videoCapturer = capturer
         mediaStreamInstance = stream
         mediaStreamPublisher.onNext(stream)
+    }
+
+    func pauseMediaStream() {
+        videoCapturer?.stopCapture()
+    }
+
+    func resumeMediaStream() {
+        startMediaStream()
     }
 
     func createAnswer(remoteSdp remoteSDP: SessionDescriptionProtocol) {

--- a/Dependencies/WebRTC/WebRtcServerManager.swift
+++ b/Dependencies/WebRTC/WebRtcServerManager.swift
@@ -110,7 +110,7 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
             }
             return
         }
-        capturer.resumeCapturing()
+        capturer.startCapturing()
         mediaStreamPublisher.onNext(stream)
     }
 

--- a/PeerConnectionFactoryProtocol.swift
+++ b/PeerConnectionFactoryProtocol.swift
@@ -35,7 +35,7 @@ extension RTCPeerConnectionFactory: PeerConnectionFactoryProtocol {
             let intFps = Int(fps)
             let capturer = RTCCameraVideoCapturer(delegate: vSource)
             let videoCapturer = WebRTCVideoCapturer(device: camera, format: format, framesPerSecond: intFps, capturer: capturer)
-            videoCapturer.resumeCapturing()
+            videoCapturer.startCapturing()
             let vTrack = videoTrack(with: vSource, trackId: "ARDAMSv0")
             localStream.addVideoTrack(vTrack)
 

--- a/PeerConnectionFactoryProtocol.swift
+++ b/PeerConnectionFactoryProtocol.swift
@@ -11,27 +11,6 @@ protocol PeerConnectionFactoryProtocol {
     func createStream() -> (VideoCapturer?, MediaStream?)
 }
 
-protocol VideoCapturer {
-    func resumeCapturing()
-    func stopCapturing()
-}
-
-struct WebRTCVideoCapturer: VideoCapturer {
-
-    let device: AVCaptureDevice
-    let format: AVCaptureDevice.Format
-    let fps: Int
-    let capturer: RTCCameraVideoCapturer
-
-    func resumeCapturing() {
-        capturer.startCapture(with: device, format: format, fps: fps)
-    }
-
-    func stopCapturing() {
-        capturer.stopCapture()
-    }
-}
-
 extension RTCPeerConnectionFactory: PeerConnectionFactoryProtocol {
 
     func peerConnection(with delegate: RTCPeerConnectionDelegate) -> PeerConnectionProtocol {

--- a/PeerConnectionFactoryProtocol.swift
+++ b/PeerConnectionFactoryProtocol.swift
@@ -34,8 +34,8 @@ extension RTCPeerConnectionFactory: PeerConnectionFactoryProtocol {
             let fps = format.videoSupportedFrameRateRanges.first?.maxFrameRate {
             let intFps = Int(fps)
             let capturer = RTCCameraVideoCapturer(delegate: vSource)
-            let videoCapturer = WebRTCVideoCapturer(device: camera, format: format, fps: intFps, capturer: capturer)
-            capturer.startCapture(with: camera, format: format, fps: intFps)
+            let videoCapturer = WebRTCVideoCapturer(device: camera, format: format, framesPerSecond: intFps, capturer: capturer)
+            videoCapturer.resumeCapturing()
             let vTrack = videoTrack(with: vSource, trackId: "ARDAMSv0")
             localStream.addVideoTrack(vTrack)
 

--- a/PeerConnectionFactoryProtocol.swift
+++ b/PeerConnectionFactoryProtocol.swift
@@ -7,13 +7,13 @@ import AVKit
 import WebRTC
 
 protocol PeerConnectionFactoryProtocol {
-    func peerConnection(with delegate: RTCPeerConnectionDelegate) -> PeerConnectionProtocol
+    func peerConnection(with delegate: PeerConnectionProxy) -> PeerConnectionProtocol
     func createStream() -> (VideoCapturer?, MediaStream?)
 }
 
 extension RTCPeerConnectionFactory: PeerConnectionFactoryProtocol {
 
-    func peerConnection(with delegate: RTCPeerConnectionDelegate) -> PeerConnectionProtocol {
+    func peerConnection(with delegate: PeerConnectionProxy) -> PeerConnectionProtocol {
         let config = RTCConfiguration()
         config.iceServers = []
         config.sdpSemantics = .unifiedPlan


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-558
 
### Task Description
<!-- What should and what actually happens. -->
 Now when the screen is changing to the energy-saving one the streaming stops.
It renews only when parent wants to preview streaming or when user taps on the screen.
When parent exits the preview screen the streaming also stops unless it's active on baby device.
