### PR TITLE
[BM-587] Memory leak on baby device

### DIFF
--- a/Baby Monitor/Source Files/Services/Reset/ApplicationResetter.swift
+++ b/Baby Monitor/Source Files/Services/Reset/ApplicationResetter.swift
@@ -79,7 +79,10 @@ private extension DefaultApplicationResetter {
     }
     
     func stopAudioKit() {
-        try? AudioKit.stop()
+         do {
+            try AudioKit.stop()
+           } catch {
+                Logger.error("AudioKit did not stop", error: error)
+           }
     }
 }
-

--- a/Baby MonitorTests/Networking/WebRTC/WebRtcServerManagerTests.swift
+++ b/Baby MonitorTests/Networking/WebRTC/WebRtcServerManagerTests.swift
@@ -249,4 +249,24 @@ class WebRtcServerManagerTests: XCTestCase {
         // Then
         XCTAssertEqual(videoCapturerMock.isCapturing, false)
     }
+
+    func testShouldStopCapturingOnStop() {
+        // Given
+        let videoCapturerMock = VideoCapturerMock()
+        let peerConnection = PeerConnectionMock()
+        let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection,
+                                                              videoCapturer: videoCapturerMock,
+                                                              mediaStream: "" as MediaStream)
+        let connectionDelegateProxy = PeerConnectionProxyMock()
+        let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
+                                      connectionDelegateProxy: connectionDelegateProxy,
+                                      scheduler: AsyncSchedulerMock())
+
+        // When
+        sut.start()
+        sut.stop()
+
+        // Then
+        XCTAssertEqual(videoCapturerMock.isCapturing, false)
+    }
 }

--- a/Dependencies/WebRTC/WebRtcServerManager.swift
+++ b/Dependencies/WebRTC/WebRtcServerManager.swift
@@ -82,6 +82,7 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
     func stop() {
         peerConnection?.close()
         isStarted = false
+        stopMediaStream()
     }
 
     private func startMediaStream() {
@@ -111,6 +112,12 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
         }
         capturer.startCapturing()
         mediaStreamPublisher.onNext(stream)
+    }
+
+    private func stopMediaStream() {
+        videoCapturer?.stopCapturing()
+        videoCapturer = nil
+        mediaStreamInstance = nil
     }
 
     func createAnswer(remoteSdp remoteSDP: SessionDescriptionProtocol) {

--- a/Dependencies/WebRTC/WebRtcServerManager.swift
+++ b/Dependencies/WebRTC/WebRtcServerManager.swift
@@ -85,14 +85,6 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
         stopMediaStream()
     }
 
-    private func startMediaStream() {
-        let (optionalCapturer, optionalStream) = peerConnectionFactory.createStream()
-        guard let capturer = optionalCapturer, let stream = optionalStream else { return }
-        videoCapturer = capturer
-        mediaStreamInstance = stream
-        mediaStreamPublisher.onNext(stream)
-    }
-
     func pauseMediaStream() {
         /// If client previews the server stream we shouldn't pause it.
         guard let capturer = videoCapturer,
@@ -114,12 +106,6 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
         mediaStreamPublisher.onNext(stream)
     }
 
-    private func stopMediaStream() {
-        videoCapturer?.stopCapturing()
-        videoCapturer = nil
-        mediaStreamInstance = nil
-    }
-
     func createAnswer(remoteSdp remoteSDP: SessionDescriptionProtocol) {
         guard isStarted else { return }
         peerConnection?.close()
@@ -131,6 +117,26 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
             }
         }
     }
+    
+    func setICECandidates(iceCandidate: IceCandidateProtocol) {
+        peerConnection?.add(iceCandidate: iceCandidate)
+    }
+
+    // MARK: Private methods.
+
+    private func startMediaStream() {
+         let (optionalCapturer, optionalStream) = peerConnectionFactory.createStream()
+         guard let capturer = optionalCapturer, let stream = optionalStream else { return }
+         videoCapturer = capturer
+         mediaStreamInstance = stream
+         mediaStreamPublisher.onNext(stream)
+     }
+
+    private func stopMediaStream() {
+          videoCapturer?.stopCapturing()
+          videoCapturer = nil
+          mediaStreamInstance = nil
+      }
 
     private func handleDidSetRemoteDescription(stream: MediaStream) {
         peerConnection?.add(stream: stream)
@@ -140,9 +146,4 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
             self.sdpAnswerPublisher.onNext(sdp)
         }
     }
-    
-    func setICECandidates(iceCandidate: IceCandidateProtocol) {
-        peerConnection?.add(iceCandidate: iceCandidate)
-    }
-    
 }


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-587
 
### Task Description
<!-- What should and what actually happens. -->
 Memory leak was in WebRTC streaming logic.