### PR TITLE
[BM-642] Remove redundant empty lines in templates

### DIFF
--- a/Baby Monitor.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/Baby Monitor.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -6,7 +6,6 @@
 <string>
 //  ___FILENAME___
 //  ___PACKAGENAME___
-//
 </string>
 </dict>
 </plist>

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,9 @@
 ### Ticket
 <!-- Link to specific ticket in your issue tracking system. -->
-https://netguru.atlassian.net/browse/BM-xxx
- 
+https://netguru.atlassian.net/browse/BM-
  
 ### Task Description
 <!-- What should and what actually happens. -->
- 
  
 ### Aditional Notes (optional)
 <!-- Provide any additional notes: related PRs, screenshots, et al.). -->


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-642
 
### Task Description
<!-- What should and what actually happens. -->
 Removed unneeded empty lines in some templates.