### PR TITLE
[BM-646] Notifications are not being sent to parent device

### DIFF
--- a/Baby Monitor/Source Files/Modules/Dashboard/DashboardCoordinator.swift
+++ b/Baby Monitor/Source Files/Modules/Dashboard/DashboardCoordinator.swift
@@ -57,8 +57,7 @@ final class DashboardCoordinator: Coordinator {
 
     // Prepare DashboardViewModel
     private func createDashboardViewModel() -> DashboardViewModel {
-        let viewModel = DashboardViewModel(networkDiscoveryConnectionStateProvider: appDependencies.connectionChecker,
-                                           socketCommunicationManager: appDependencies.socketCommunicationsManager,
+        let viewModel = DashboardViewModel(socketCommunicationManager: appDependencies.socketCommunicationsManager,
                                            babyModelController: appDependencies.databaseRepository,
                                            webSocketEventMessageService: appDependencies.webSocketEventMessageService,
                                            microphonePermissionProvider:  appDependencies.microphonePermissionProvider)

--- a/Baby MonitorTests/Modules/Dashboard/DashboardViewModelTests.swift
+++ b/Baby MonitorTests/Modules/Dashboard/DashboardViewModelTests.swift
@@ -26,34 +26,16 @@ class DashboardViewModelTests: XCTestCase {
     func testShouldStartConnectionCheckingOnCreation() {
         // Given
         let babiesRepository = DatabaseRepositoryMock()
-        let connectionChecker = ConnectionCheckerMock()
         let webSocketEventMessageServiceMock = WebSocketEventMessageServiceMock()
         let microphonePermissionProviderMock = MicrophonePermissionProviderMock()
         let socketCommunicationManagerMock = SocketCommunicationManagerMock()
         
         // When
         // We assign it to the reference to ensure that it doesn't got deallocated
-        let sut = DashboardViewModel(networkDiscoveryConnectionStateProvider: connectionChecker, socketCommunicationManager: socketCommunicationManagerMock, babyModelController: babiesRepository, webSocketEventMessageService: webSocketEventMessageServiceMock, microphonePermissionProvider: microphonePermissionProviderMock)
+        let sut = DashboardViewModel(socketCommunicationManager: socketCommunicationManagerMock, babyModelController: babiesRepository, webSocketEventMessageService: webSocketEventMessageServiceMock, microphonePermissionProvider: microphonePermissionProviderMock)
         
         // Then
-        XCTAssertTrue(connectionChecker.isStarted)
         XCTAssertNotNil(sut)
-    }
-    
-    func testShouldEndConnectionOnDeallocation() {
-        // Given
-        let babiesRepository = DatabaseRepositoryMock()
-        let connectionChecker = ConnectionCheckerMock()
-        let webSocketEventMessageServiceMock = WebSocketEventMessageServiceMock()
-        let microphonePermissionProviderMock = MicrophonePermissionProviderMock()
-        let socketCommunicationManagerMock = SocketCommunicationManagerMock()
-        
-        // When
-        // And here we don't
-        _ = DashboardViewModel(networkDiscoveryConnectionStateProvider: connectionChecker, socketCommunicationManager: socketCommunicationManagerMock, babyModelController: babiesRepository, webSocketEventMessageService: webSocketEventMessageServiceMock, microphonePermissionProvider: microphonePermissionProviderMock)
-        
-        // Then
-        XCTAssertFalse(connectionChecker.isStarted)
     }
     
     func testShouldForwardLiveCameraTap() {
@@ -61,11 +43,10 @@ class DashboardViewModelTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let observer = scheduler.createObserver(Void.self)
         let babiesRepository = DatabaseRepositoryMock()
-        let connectionChecker = ConnectionCheckerMock()
         let webSocketEventMessageServiceMock = WebSocketEventMessageServiceMock()
         let microphonePermissionProviderMock = MicrophonePermissionProviderMock()
         let socketCommunicationManagerMock = SocketCommunicationManagerMock()
-        let sut = DashboardViewModel(networkDiscoveryConnectionStateProvider: connectionChecker, socketCommunicationManager: socketCommunicationManagerMock, babyModelController: babiesRepository, webSocketEventMessageService: webSocketEventMessageServiceMock, microphonePermissionProvider: microphonePermissionProviderMock)
+        let sut = DashboardViewModel(socketCommunicationManager: socketCommunicationManagerMock, babyModelController: babiesRepository, webSocketEventMessageService: webSocketEventMessageServiceMock, microphonePermissionProvider: microphonePermissionProviderMock)
         sut.attachInput(liveCameraTap: liveCameraTap, activityLogTap: activityLogTap, settingsTap: settingsTap)
         sut.liveCameraPreview?
             .subscribe(observer)
@@ -83,11 +64,10 @@ class DashboardViewModelTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let observer = scheduler.createObserver(Void.self)
         let babiesRepository = DatabaseRepositoryMock()
-        let connectionChecker = ConnectionCheckerMock()
         let webSocketEventMessageServiceMock = WebSocketEventMessageServiceMock()
         let microphonePermissionProviderMock = MicrophonePermissionProviderMock()
         let socketCommunicationManagerMock = SocketCommunicationManagerMock()
-        let sut = DashboardViewModel(networkDiscoveryConnectionStateProvider: connectionChecker, socketCommunicationManager: socketCommunicationManagerMock, babyModelController: babiesRepository, webSocketEventMessageService: webSocketEventMessageServiceMock, microphonePermissionProvider: microphonePermissionProviderMock)
+        let sut = DashboardViewModel(socketCommunicationManager: socketCommunicationManagerMock, babyModelController: babiesRepository, webSocketEventMessageService: webSocketEventMessageServiceMock, microphonePermissionProvider: microphonePermissionProviderMock)
         sut.attachInput(liveCameraTap: liveCameraTap, activityLogTap: activityLogTap, settingsTap: settingsTap)
         sut.activityLogTap?
             .subscribe(observer)


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-646
 
### Task Description
<!-- What should and what actually happens. -->
The device token was not being sent, as when the feature with multiple devices came - the connection should be terminated after pairing. So, the fix is to remove checking whether the connection is done as long as the user will never be on that screen if it's not. 
