### PR TITLE
[BM-626] Add WebRtc stream basic error handling

### DIFF
--- a/Baby Monitor/Source Files/AppDependencies.swift
+++ b/Baby Monitor/Source Files/AppDependencies.swift
@@ -45,7 +45,9 @@ final class AppDependencies {
     private(set) lazy var webRtcConnectionProxy: PeerConnectionProxy = RTCPeerConnectionDelegateProxy()
 
     private(set) lazy var webRtcServer: () -> WebRtcServerManagerProtocol = {
-        WebRtcServerManager(peerConnectionFactory: self.peerConnectionFactory, connectionDelegateProxy: self.webRtcConnectionProxy)
+        WebRtcServerManager(peerConnectionFactory: self.peerConnectionFactory,
+                            connectionDelegateProxy: self.webRtcConnectionProxy,
+                            messageServer: self.messageServer)
     }
     
     private(set) lazy var webRtcClient: () -> WebRtcClientManagerProtocol = {

--- a/Baby Monitor/Source Files/Localizations/Localizable.swift
+++ b/Baby Monitor/Source Files/Localizations/Localizable.swift
@@ -167,6 +167,8 @@ enum Localizable {
         static let babyIsCrying = localized("server.baby-is-crying")
         static let babyStoppedCrying = localized("server.baby-stopped-crying")
         static let audioRecordError = localized("server.audio-record-error")
+        static let streamError = localized("server.stream-error")
+        static let noStream = localized("server.no-stream")
     }
     
     enum Lullabies {

--- a/Baby Monitor/Source Files/Localizations/en.lproj/Localizable.strings
+++ b/Baby Monitor/Source Files/Localizations/en.lproj/Localizable.strings
@@ -122,6 +122,8 @@
 "server.baby-stopped-crying" = "Baby stopped crying!";
 "server.baby-is-crying" = "Baby is crying!";
 "server.audio-record-error" = "There is some error with audio recording. Please turn app again.";
+"server.stream-error" = "There is some error with connecting to the stream.";
+"server.no-stream" = "No stream available.";
 
 //MARK: - Activity Log
 "activity-log.title" = "Latest activity";

--- a/Baby Monitor/Source Files/Modules/CameraPreview/CameraPreviewViewController.swift
+++ b/Baby Monitor/Source Files/Modules/CameraPreview/CameraPreviewViewController.swift
@@ -90,6 +90,11 @@ final class CameraPreviewViewController: TypedViewController<CameraPreviewView> 
                 self?.attach(stream: stream)
             })
             .disposed(by: bag)
+        viewModel.remoteStreamErrorMessageObservable
+            .subscribe(onNext: { [weak self] message in
+                self?.handleStreamError(errorMessage: message)
+            })
+            .disposed(by: bag)
     }
     
     private func attach(stream: MediaStream) {
@@ -99,5 +104,14 @@ final class CameraPreviewViewController: TypedViewController<CameraPreviewView> 
         videoTrack?.remove(videoView)
         videoTrack = stream.videoTracks[0]
         videoTrack?.add(videoView)
+    }
+
+    private func handleStreamError(errorMessage: String) {
+        let alertController = UIAlertController(title: Localizable.Server.streamError, message: errorMessage, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: Localizable.General.ok, style: .default, handler: { _ in
+            self.navigationController?.popViewController(animated: true)
+        })
+        alertController.addAction(okAction)
+        self.present(alertController, animated: true, completion: nil)
     }
 }

--- a/Baby Monitor/Source Files/Modules/CameraPreview/CameraPreviewViewController.swift
+++ b/Baby Monitor/Source Files/Modules/CameraPreview/CameraPreviewViewController.swift
@@ -112,6 +112,6 @@ final class CameraPreviewViewController: TypedViewController<CameraPreviewView> 
             self.navigationController?.popViewController(animated: true)
         })
         alertController.addAction(okAction)
-        self.present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 }

--- a/Baby Monitor/Source Files/Modules/CameraPreview/CameraPreviewViewModel.swift
+++ b/Baby Monitor/Source Files/Modules/CameraPreview/CameraPreviewViewModel.swift
@@ -9,6 +9,9 @@ final class CameraPreviewViewModel {
     
     let bag = DisposeBag()
     lazy var baby: Observable<Baby> = babyModelController.babyUpdateObservable
+    var remoteStreamErrorMessageObservable: Observable<String> {
+        return self.webSocketEventMessageService.remoteStreamConnectingErrorObservable
+    }
     private(set) var streamResettedPublisher = PublishSubject<Void>()
     private(set) var cancelTap: Observable<Void>?
     private(set) var settingsTap: Observable<Void>?
@@ -24,13 +27,16 @@ final class CameraPreviewViewModel {
     private let babyModelController: BabyModelControllerProtocol
     private unowned var webSocketWebRtcService: ClearableLazyItem<WebSocketWebRtcServiceProtocol>
     private unowned var socketCommunicationManager: SocketCommunicationManager
-    
+    private let webSocketEventMessageService: WebSocketEventMessageServiceProtocol
+
     init(webSocketWebRtcService: ClearableLazyItem<WebSocketWebRtcServiceProtocol>,
         babyModelController: BabyModelControllerProtocol,
-        socketCommunicationManager: SocketCommunicationManager) {
+        socketCommunicationManager: SocketCommunicationManager,
+        webSocketEventMessageService: WebSocketEventMessageServiceProtocol) {
         self.webSocketWebRtcService = webSocketWebRtcService
         self.babyModelController = babyModelController
         self.socketCommunicationManager = socketCommunicationManager
+        self.webSocketEventMessageService = webSocketEventMessageService
         rxSetup()
     }
     

--- a/Baby Monitor/Source Files/Modules/Dashboard/DashboardCoordinator.swift
+++ b/Baby Monitor/Source Files/Modules/Dashboard/DashboardCoordinator.swift
@@ -120,7 +120,8 @@ final class DashboardCoordinator: Coordinator {
         let viewModel = CameraPreviewViewModel(
             webSocketWebRtcService: appDependencies.webSocketWebRtcService,
             babyModelController: appDependencies.databaseRepository,
-            socketCommunicationManager: appDependencies.socketCommunicationsManager)
+            socketCommunicationManager: appDependencies.socketCommunicationsManager,
+            webSocketEventMessageService: appDependencies.webSocketEventMessageService)
         return viewModel
     }
     

--- a/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcServerManagerProtocol.swift
+++ b/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcServerManagerProtocol.swift
@@ -21,7 +21,9 @@ protocol WebRtcServerManagerProtocol {
 
     /// Sets session description answer
     ///
-    /// - Parameter sdp: session description protocol to add
+    /// - Parameters:
+    ///     - sdp: session description protocol to add.
+    ///     - completion: a completion called when the creating answer was finished.
     func createAnswer(remoteSdp: SessionDescriptionProtocol, completion: @escaping (_ isSuccessful: Bool) -> Void)
 
     /// Adds ice candidate

--- a/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcServerManagerProtocol.swift
+++ b/Baby Monitor/Source Files/Services/Connection/WebRTC/WebRtcServerManagerProtocol.swift
@@ -22,7 +22,7 @@ protocol WebRtcServerManagerProtocol {
     /// Sets session description answer
     ///
     /// - Parameter sdp: session description protocol to add
-    func createAnswer(remoteSdp: SessionDescriptionProtocol)
+    func createAnswer(remoteSdp: SessionDescriptionProtocol, completion: @escaping (_ isSuccessful: Bool) -> Void)
 
     /// Adds ice candidate
     ///

--- a/Baby Monitor/Source Files/Services/Other/AlertPresenter.swift
+++ b/Baby Monitor/Source Files/Services/Other/AlertPresenter.swift
@@ -28,7 +28,7 @@ struct AlertPresenter {
                     }
                 }
             } else {
-                let alertAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+                let alertAction = UIAlertAction(title: Localizable.General.ok, style: .default, handler: nil)
                 actionsToAdd.append(alertAction)
             }
             actionsToAdd.forEach {

--- a/Baby Monitor/Source Files/Services/ServerService.swift
+++ b/Baby Monitor/Source Files/Services/ServerService.swift
@@ -111,7 +111,7 @@ final class ServerService: ServerServiceProtocol {
         case .iceCandidate(let iceCandidate):
             webRtcServerManager.setICECandidates(iceCandidate: iceCandidate)
         case .sdpOffer(let sdp):
-            webRtcServerManager.createAnswer(remoteSdp: sdp)
+            webRtcServerManager.createAnswer(remoteSdp: sdp, completion: { _ in })
         default:
             break
         }

--- a/Baby Monitor/Source Files/Services/Websocket/Models/EventMessage.swift
+++ b/Baby Monitor/Source Files/Services/Websocket/Models/EventMessage.swift
@@ -10,6 +10,7 @@ enum BabyMonitorEvent: String, CodingKey {
     case actionKey = "action"
     case pairingCodeKey = "pairingCode"
     case pairingCodeResponseKey = "pairingResponse"
+    case webRtcSdpErrorKey = "sdpError"
 }
 
 enum BabyMonitorEvenAction: String, Codable {
@@ -21,6 +22,7 @@ struct EventMessage {
     var action: BabyMonitorEvenAction?
     var pairingCode: String?
     var pairingCodeResponse: Bool?
+    var webRtcSdpErrorMessage: String?
 }
 
 extension EventMessage: Codable {
@@ -31,6 +33,7 @@ extension EventMessage: Codable {
         action = try container.decodeIfPresent(BabyMonitorEvenAction.self, forKey: .actionKey)
         pairingCode = try container.decodeIfPresent(String.self, forKey: .pairingCodeKey)
         pairingCodeResponse = try container.decodeIfPresent(Bool.self, forKey: .pairingCodeResponseKey)
+        webRtcSdpErrorMessage = try container.decodeIfPresent(String.self, forKey: .webRtcSdpErrorKey)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -39,5 +42,6 @@ extension EventMessage: Codable {
         try container.encodeIfPresent(action, forKey: .actionKey)
         try container.encodeIfPresent(pairingCode, forKey: .pairingCodeKey)
         try container.encodeIfPresent(pairingCodeResponse, forKey: .pairingCodeResponseKey)
+        try container.encodeIfPresent(webRtcSdpErrorMessage, forKey: .webRtcSdpErrorKey)
     }
 }

--- a/Baby Monitor/Source Files/Services/Websocket/WebSocketEventMessageService.swift
+++ b/Baby Monitor/Source Files/Services/Websocket/WebSocketEventMessageService.swift
@@ -8,7 +8,7 @@ import RxSwift
 protocol WebSocketEventMessageServiceProtocol: class {
     var remoteResetObservable: Observable<Void> { get }
     var remotePairingCodeResponseObservable: Observable<Bool> { get }
-
+    var remoteStreamConnectingErrorObservable: Observable<String> { get }
     func start()
     func close()
     func sendMessage(_ message: String)
@@ -18,11 +18,13 @@ final class WebSocketEventMessageService: WebSocketEventMessageServiceProtocol {
 
     private(set) lazy var remoteResetObservable = remoteResetPublisher.asObservable()
     private(set) lazy var remotePairingCodeResponseObservable = remotePairingCodeResponsePublisher.asObservable()
+    private(set) lazy var remoteStreamConnectingErrorObservable = remoteStreamConnectingErrorPublisher.asObservable()
 
     private var eventMessageConductor: WebSocketConductorProtocol?
     private let eventMessagePublisher = PublishSubject<String>()
     private let remoteResetPublisher = PublishSubject<Void>()
     private let remotePairingCodeResponsePublisher = PublishSubject<Bool>()
+    private let remoteStreamConnectingErrorPublisher = PublishSubject<String>()
 
     init(cryingEventsRepository: ActivityLogEventsRepositoryProtocol, eventMessageConductorFactory: (Observable<String>, AnyObserver<EventMessage>?) -> WebSocketConductorProtocol) {
         setupEventMessageConductor(with: eventMessageConductorFactory)
@@ -42,6 +44,9 @@ final class WebSocketEventMessageService: WebSocketEventMessageServiceProtocol {
             }
             if let isPairingApproved = event.pairingCodeResponse {
                 self?.remotePairingCodeResponsePublisher.onNext(isPairingApproved)
+            }
+            if let webRtcSdpErrorMessage = event.webRtcSdpErrorMessage {
+                self?.remoteStreamConnectingErrorPublisher.onNext(webRtcSdpErrorMessage)
             }
         })
     }

--- a/Baby MonitorTests/Mocks/PeerConnectionMock.swift
+++ b/Baby MonitorTests/Mocks/PeerConnectionMock.swift
@@ -8,6 +8,7 @@ import WebRTC
 
 final class PeerConnectionMock: PeerConnectionProtocol {
 
+    var shouldSetRemoteDescriptionFail = false
     private(set) var isConnected = true
     private(set) var remoteSdp: SessionDescriptionProtocol?
     private(set) var localSdp: SessionDescriptionProtocol?
@@ -25,11 +26,17 @@ final class PeerConnectionMock: PeerConnectionProtocol {
     }
 
     func setRemoteDescription(sdp: SessionDescriptionProtocol, handler: ((Error?) -> Void)?) {
-        self.remoteSdp = sdp
+        if shouldSetRemoteDescriptionFail {
+            handler?(NSError(domain: "domain", code: 0, userInfo: nil))
+        } else {
+            self.remoteSdp = sdp
+            handler?(nil)
+        }
     }
 
     func setLocalDescription(sdp: SessionDescriptionProtocol, handler: ((Error?) -> Void)?) {
         self.localSdp = sdp
+        handler?(nil)
     }
 
     func add(iceCandidate: IceCandidateProtocol) {

--- a/Baby MonitorTests/Mocks/WebRtcServerManagerMock.swift
+++ b/Baby MonitorTests/Mocks/WebRtcServerManagerMock.swift
@@ -27,12 +27,14 @@ final class WebRtcServerManagerMock: WebRtcServerManagerProtocol {
         isSetup = true
     }
 
-    func createAnswer(remoteSdp: SessionDescriptionProtocol) {
+    func createAnswer(remoteSdp: SessionDescriptionProtocol, completion: @escaping (_ isSuccessful: Bool) -> Void) {
         self.remoteSdp = remoteSdp
         guard let localSdp = localSdp else {
+            completion(false)
             return
         }
         sdpAnswerPublisher.onNext(localSdp)
+        completion(true)
     }
 
     func setICECandidates(iceCandidate: IceCandidateProtocol) {

--- a/Baby MonitorTests/Mocks/WebSocketEventMessageServiceMock.swift
+++ b/Baby MonitorTests/Mocks/WebSocketEventMessageServiceMock.swift
@@ -10,8 +10,10 @@ final class WebSocketEventMessageServiceMock: WebSocketEventMessageServiceProtoc
 
     lazy var remoteResetObservable: Observable<Void> = remoteResetPublisher.asObservable()
     lazy var remotePairingCodeResponseObservable: Observable<Bool> = remotePairingCodeResponsePublisher.asObservable()
-    private let remoteResetPublisher = PublishSubject<Void>()
+    lazy var remoteStreamConnectingErrorObservable: Observable<String> = remoteStreamConnectingErrorPublisher.asObservable()
     let remotePairingCodeResponsePublisher = PublishSubject<Bool>()
+    private let remoteResetPublisher = PublishSubject<Void>()
+    private let remoteStreamConnectingErrorPublisher = PublishSubject<String>()
     private(set) var isOpen = false
     private(set) var messages = [String]()
 

--- a/Baby MonitorTests/Networking/WebRTC/WebRtcServerManagerTests.swift
+++ b/Baby MonitorTests/Networking/WebRTC/WebRtcServerManagerTests.swift
@@ -16,9 +16,11 @@ class WebRtcServerManagerTests: XCTestCase {
         let peerConnection = PeerConnectionMock()
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         // When
         sut.start()
@@ -36,9 +38,11 @@ class WebRtcServerManagerTests: XCTestCase {
         let peerConnection = PeerConnectionMock()
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         // When
         sut.start()
@@ -55,9 +59,11 @@ class WebRtcServerManagerTests: XCTestCase {
         let peerConnection = PeerConnectionMock()
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         // When
         sut.start()
@@ -80,9 +86,11 @@ class WebRtcServerManagerTests: XCTestCase {
                                                               videoCapturer: videoCapturerMock,
                                                               mediaStream: streamId as MediaStream)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         sut.mediaStream
             .subscribe(observer)
@@ -107,9 +115,11 @@ class WebRtcServerManagerTests: XCTestCase {
                                                               videoCapturer: nil,
                                                               mediaStream: streamId as MediaStream)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         sut.mediaStream
             .subscribe(observer)
@@ -128,9 +138,11 @@ class WebRtcServerManagerTests: XCTestCase {
         let peerConnection = PeerConnectionMock()
         let peerConnectionFactory = PeerConnectionFactoryMock(peerConnectionProtocol: peerConnection, videoCapturer: videoCapturerMock)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         // When
         sut.start()
@@ -147,9 +159,11 @@ class WebRtcServerManagerTests: XCTestCase {
                                                               videoCapturer: videoCapturerMock,
                                                               mediaStream: "" as MediaStream)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         // When
         sut.start()
@@ -167,9 +181,11 @@ class WebRtcServerManagerTests: XCTestCase {
                                                               videoCapturer: videoCapturerMock,
                                                               mediaStream: "" as MediaStream)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         // When
         sut.start()
@@ -192,9 +208,11 @@ class WebRtcServerManagerTests: XCTestCase {
                                                               videoCapturer: videoCapturerMock,
                                                               mediaStream: streamId as MediaStream)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         sut.mediaStream
             .subscribe(observer)
@@ -217,9 +235,11 @@ class WebRtcServerManagerTests: XCTestCase {
                                                               videoCapturer: videoCapturerMock,
                                                               mediaStream: "" as MediaStream)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         // When
         sut.start()
@@ -238,9 +258,11 @@ class WebRtcServerManagerTests: XCTestCase {
                                                               videoCapturer: videoCapturerMock,
                                                               mediaStream: "" as MediaStream)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         // When
         sut.start()
@@ -258,9 +280,11 @@ class WebRtcServerManagerTests: XCTestCase {
                                                               videoCapturer: videoCapturerMock,
                                                               mediaStream: "" as MediaStream)
         let connectionDelegateProxy = PeerConnectionProxyMock()
+        let messageServer = MessageServerMock()
         let sut = WebRtcServerManager(peerConnectionFactory: peerConnectionFactory,
                                       connectionDelegateProxy: connectionDelegateProxy,
-                                      scheduler: AsyncSchedulerMock())
+                                      scheduler: AsyncSchedulerMock(),
+                                      messageServer: messageServer)
 
         // When
         sut.start()

--- a/Dependencies/WebRTC/WebRtcServerManager.swift
+++ b/Dependencies/WebRTC/WebRtcServerManager.swift
@@ -119,9 +119,12 @@ final class WebRtcServerManager: NSObject, WebRtcServerManagerProtocol {
             self.peerConnection?.setRemoteDescription(sdp: remoteSDP) { [weak self] error in
                 if let error = error {
                     self?.messageServer.send(message: EventMessage(webRtcSdpErrorMessage: error.localizedDescription).toStringMessage())
+                    Logger.error("Set remote description error.", error: error)
+                    return
                 }
                 guard let stream = self?.mediaStreamInstance else {
                     self?.messageServer.send(message: EventMessage(webRtcSdpErrorMessage: Localizable.Server.noStream).toStringMessage())
+                    Logger.error("Set remote description error: no stream")
                     return
                 }
                 self?.handleDidSetRemoteDescription(stream: stream)


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-626
 
### Task Description
<!-- What should and what actually happens. -->
When webRTC encounters a streaming error, the baby device will inform a parent device, and the latter will show an alert with the message “Error connecting to the stream” and will exit the preview camera view.