### PR TITLE
[BM-572] Parent device - stream freeze after about 10 seconds of watching the stream on iOS 13.2 on iPhone 11

### DIFF
--- a/PeerConnectionFactoryProtocol.swift
+++ b/PeerConnectionFactoryProtocol.swift
@@ -36,6 +36,7 @@ extension RTCPeerConnectionFactory: PeerConnectionFactoryProtocol {
             let capturer = RTCCameraVideoCapturer(delegate: vSource)
             let videoCapturer = WebRTCVideoCapturer(device: camera, format: format, framesPerSecond: intFps, capturer: capturer)
             videoCapturer.startCapturing()
+            vSource.adaptOutputFormat(toWidth: 640, height: 480, fps: 30)
             let vTrack = videoTrack(with: vSource, trackId: "ARDAMSv0")
             localStream.addVideoTrack(vTrack)
 

--- a/PeerConnectionFactoryProtocol.swift
+++ b/PeerConnectionFactoryProtocol.swift
@@ -36,6 +36,7 @@ extension RTCPeerConnectionFactory: PeerConnectionFactoryProtocol {
             let capturer = RTCCameraVideoCapturer(delegate: vSource)
             let videoCapturer = WebRTCVideoCapturer(device: camera, format: format, framesPerSecond: intFps, capturer: capturer)
             videoCapturer.startCapturing()
+            // The next line is a fix for a stream freeze on iOS 13.
             vSource.adaptOutputFormat(toWidth: 640, height: 480, fps: 30)
             let vTrack = videoTrack(with: vSource, trackId: "ARDAMSv0")
             localStream.addVideoTrack(vTrack)


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-572
 
### Task Description
<!-- What should and what actually happens. -->
 This is a fix for a stream freeze on iOS 13. A solution found on a radar attached below by @gabrysgab . 

### Aditional Notes (optional)
<!-- Provide any additional notes: related PRs, screenshots, et al.). -->
https://bugs.chromium.org/p/webrtc/issues/detail?id=9134