### PR TITLE
[BM-655] Do not reconnect with stream unless in camera preview screen

### DIFF
--- a/Baby Monitor/Source Files/Services/Connection/SocketCommunicationManager.swift
+++ b/Baby Monitor/Source Files/Services/Connection/SocketCommunicationManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 import RxSwift
 
-protocol SocketCommunicationManager: class, WebSocketConnectionStatusProvider {
+protocol SocketCommunicationManager: AnyObject, WebSocketConnectionStatusProvider {
     var communicationResetObservable: Observable<Void> { get }
     var communicationTerminationObservable: Observable<Void> { get }
     func reset()
@@ -27,8 +27,8 @@ class DefaultSocketCommunicationManager: SocketCommunicationManager {
     private let bag = DisposeBag()
     
     init(webSocketEventMessageService: WebSocketEventMessageServiceProtocol,
-        webSocketWebRtcService: ClearableLazyItem<WebSocketWebRtcServiceProtocol>,
-        webSocket: ClearableLazyItem<WebSocketProtocol?>) {
+         webSocketWebRtcService: ClearableLazyItem<WebSocketWebRtcServiceProtocol>,
+         webSocket: ClearableLazyItem<WebSocketProtocol?>) {
         self.webSocketEventMessageService = webSocketEventMessageService
         self.webSocketWebRtcService = webSocketWebRtcService
         self.webSocket = webSocket

--- a/Baby Monitor/Source Files/Services/Connection/SocketCommunicationManager.swift
+++ b/Baby Monitor/Source Files/Services/Connection/SocketCommunicationManager.swift
@@ -38,7 +38,6 @@ class DefaultSocketCommunicationManager: SocketCommunicationManager {
     func reset() {
         terminate()
         webSocketEventMessageService.start()
-        webSocketWebRtcService.get().start()
         communicationResetPublisher.onNext(())
         setupRx()
     }

--- a/Baby MonitorTests/Mocks/WebRtcClientManagerMock.swift
+++ b/Baby MonitorTests/Mocks/WebRtcClientManagerMock.swift
@@ -21,7 +21,6 @@ final class WebRtcClientManagerMock: WebRtcClientManagerProtocol {
         self.connectionStatusObservable = statePublisher.asObservable()
     }
     
-    
     func startIfNeeded() {
         isStarted = true
         guard let localSdp = localSdp else {

--- a/Baby MonitorTests/Modules/Communication/SocketCommunicationManagerTests.swift
+++ b/Baby MonitorTests/Modules/Communication/SocketCommunicationManagerTests.swift
@@ -50,7 +50,6 @@ class SocketCommunicationManagerTests: XCTestCase {
         sut.reset()
         
         //  Then:
-        XCTAssertEqual(webSocketWebRtcMockWrapper.isCleared, false)
         XCTAssertEqual(terminationObserver.events.count, 1)
         XCTAssertEqual(resetObserver.events.count, 1)
     }

--- a/Dependencies/WebRTC/WebRtcClientManager.swift
+++ b/Dependencies/WebRTC/WebRtcClientManager.swift
@@ -23,8 +23,7 @@ final class WebRtcClientManager: NSObject, WebRtcClientManagerProtocol {
     var mediaStream: Observable<MediaStream?> {
         return mediaStreamPublisher
     }
-    
-    
+
     private var isStarted = false
     private(set) var connectionStatusObservable: Observable<WebSocketConnectionStatus>
     private let sdpOfferPublisher = PublishSubject<SessionDescriptionProtocol>()


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-655
 
### Task Description
<!-- What should and what actually happens. -->
 There was a bug when the parent app was reconnecting with stream randomly when not in the camera preview screen. The reason was reconnection after socket communication was lost after the phone lock. The stream reconnection was removed as it is handled in the camera preview screen.
