### PR TITLE
[BM-671] Fix an audio freezing on iOS 12

### DIFF
--- a/Baby Monitor/Source Files/Services/MediaPlayer/MicrophoneFactory.swift
+++ b/Baby Monitor/Source Files/Services/MediaPlayer/MicrophoneFactory.swift
@@ -45,7 +45,7 @@ enum AudioKitMicrophoneFactory {
 
         let silentRecorderMixer = AKMixer(recorderMixer)
         silentRecorderMixer.volume = 0
-        let silentCapturerMixer = AKMixer(capturerMixer)
+        let silentCapturerMixer = AKMixer(tracker)
         silentCapturerMixer.volume = 0
 
         let outputMixer = AKMixer(silentRecorderMixer, silentCapturerMixer)


### PR DESCRIPTION
### Ticket
<!-- Link to specific ticket in your issue tracking system. -->
https://netguru.atlassian.net/browse/BM-671
 
### Task Description
<!-- What should and what actually happens. -->
 After sending audio via WebRTC it was stoping capturing and recognize sound at all on iOS 12. This fixes the issue.
